### PR TITLE
feat(docking): propagate interactive box geometry to pocket

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -209,7 +209,8 @@ ignores it in v1. `None` when unset or identity.
 _Avoid_: Apply; pocket rotation; treating printed cell output as live
 
 **Box commit**:
-Kernel write of session rotation from a molstar gesture-end whose `rotationDeg`
-changed. Appearance-only molstar edits (color, size, visibility) are not box
-commits.
-_Avoid_: Apply to notebook; conflating with center/size edits
+Kernel write of docking search-box geometry from a molstar gesture-end. Commits
+updated `center` and `box_size` onto `Pocket`, plus `rotationDeg` as session
+rotation on the `Docking` instance. Appearance-only molstar edits (color,
+visibility) are not box commits.
+_Avoid_: Apply to notebook; treating resize/recenter as visualization-only edits

--- a/docs/agents/merge-ready-lessons.md
+++ b/docs/agents/merge-ready-lessons.md
@@ -1,6 +1,6 @@
-# merge-ready lessons
+## 2026-08-19 — PR #606 — interactive box geometry sync
 
-Notes from past merge-ready cycles. Read before starting; append after success.
+Pre-commit `nb-clean` promotion can inject `protein.sync()` into notebook setup cells; verify clean notebooks after commit when claiming “no platform sync until run”. Copilot catches this reliably — resolve before re-review.
 
 ## 2026-08-14 — PR #604 — ProteinPrep async wrapper
 

--- a/docs/notebooks/clean/interactive-docking-box.ipynb
+++ b/docs/notebooks/clean/interactive-docking-box.ipynb
@@ -79,7 +79,6 @@
    "outputs": [],
    "source": [
     "protein = Protein.from_file(BRD_DATA_DIR / \"brd.pdb\")\n",
-    "protein.sync()\n",
     "\n",
     "ligand = Ligand.from_sdf(BRD_DATA_DIR / \"brd-2.sdf\")\n",
     "\n",

--- a/docs/notebooks/clean/interactive-docking-box.ipynb
+++ b/docs/notebooks/clean/interactive-docking-box.ipynb
@@ -2,34 +2,26 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "77363231",
+   "id": "2c1e463f",
    "metadata": {},
    "source": [
-    "# Interactive docking box (DDOS-6928)\n",
+    "# Interactive docking box\n",
     "\n",
-    "Demo of production `Docking.show_box(interactive=True)` — rotate the search box in\n",
-    "molstar. The overlay shows `Synced rotation_deg=…` when Python has the orientation.\n",
-    "Re-run the inspect cell to print `docking.rotation_deg` (printed output does not\n",
-    "update live).\n",
+    "Adjust the docking search box in Mol* — resize, recenter, or rotate it — then\n",
+    "dock with the updated geometry.\n",
     "\n",
-    "## How to run\n",
+    "Open **Settings → Docking Box** in the viewer after running the interactive cell\n",
+    "below. When you release the mouse or slider, the box geometry syncs back to your\n",
+    "`Docking` object. Re-run the inspect cells to see the updated pocket and payload.\n",
     "\n",
-    "```bash\n",
-    "make demo-interactive-docking-box\n",
-    "```\n",
-    "\n",
-    "This syncs `dev` + `core` + `tools` into `.venv`, registers the **Python (do-dd-client)**\n",
-    "kernel, and opens JupyterLab in your browser. Select that kernel if prompted.\n",
-    "\n",
-    "The interactive viewer uses bundled BRD fixtures (no platform sync). The **Run\n",
-    "rotated docking** section at the bottom calls the platform — you need `deeporigin login`,\n",
-    "a billing-enabled org, and toolbox docking **3.4.32+** deployed."
+    "This notebook uses bundled BRD4 demo structures (`BRD_DATA_DIR`). No platform sync\n",
+    "is required until you run docking at the end."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79b79380",
+   "id": "e820ca4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72dc7879",
+   "id": "b7da4104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,125 +43,47 @@
   },
   {
    "cell_type": "markdown",
-   "id": "537b1a69",
+   "id": "12d80707",
    "metadata": {},
    "source": [
-    "## Kernel check\n",
-    "\n",
-    "Run the cell below first. If it errors, your notebook kernel is **not** the project\n",
-    "`.venv` — widgets will show as text (`<_IframeCommWidget object at ...>`) instead of\n",
-    "rendering. Fix with:\n",
-    "\n",
-    "```bash\n",
-    "cd /path/to/do-dd-client\n",
-    "make jupyter\n",
-    "```\n",
-    "\n",
-    "Then in the notebook: **Kernel → Change Kernel → Python (do-dd-client)**.\n",
-    "\n",
-    "Use **browser JupyterLab** from `make demo-interactive-docking-box` (not a mismatched\n",
-    "interpreter in a multi-root workspace)."
+    "## Setup"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5dcdf2ba",
+   "id": "306b02c8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import anywidget\n",
-    "import ipywidgets\n",
-    "\n",
-    "\n",
-    "def _find_repo_root() -> Path:\n",
-    "    \"\"\"Return do-dd-client root from repo root or docs/notebooks/dirty/.\"\"\"\n",
-    "    path = Path.cwd().resolve()\n",
-    "    for candidate in (path, *path.parents):\n",
-    "        if (candidate / \"pyproject.toml\").is_file() and (candidate / \"tests\").is_dir():\n",
-    "            return candidate\n",
-    "    raise RuntimeError(\n",
-    "        \"Open this notebook from do-dd-client (repo root or docs/notebooks/dirty/).\"\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "def _expected_python(repo_root: Path) -> Path:\n",
-    "    \"\"\"Return the project venv interpreter.\"\"\"\n",
-    "    for name in (\"python\", \"python3\"):\n",
-    "        candidate = repo_root / \".venv\" / \"bin\" / name\n",
-    "        if candidate.is_file():\n",
-    "            return candidate.resolve()\n",
-    "    raise RuntimeError(f\"No .venv interpreter under {repo_root}\")\n",
-    "\n",
-    "\n",
-    "REPO_ROOT = _find_repo_root()\n",
-    "EXPECTED_PYTHON = _expected_python(REPO_ROOT)\n",
-    "ACTUAL_PYTHON = Path(sys.executable).resolve()\n",
-    "\n",
-    "if ACTUAL_PYTHON != EXPECTED_PYTHON:\n",
-    "    raise RuntimeError(\n",
-    "        \"Wrong notebook kernel for widget rendering.\\n\"\n",
-    "        f\"  active:   {ACTUAL_PYTHON}\\n\"\n",
-    "        f\"  expected: {EXPECTED_PYTHON}\\n\"\n",
-    "        \"Run `make jupyter` and select kernel 'Python (do-dd-client)'.\"\n",
-    "    )\n",
-    "\n",
-    "print(\"Kernel OK\")\n",
-    "print(f\"  python:     {ACTUAL_PYTHON}\")\n",
-    "print(f\"  anywidget:  {anywidget.__version__}\")\n",
-    "print(f\"  ipywidgets: {ipywidgets.__version__}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d4eb3b0c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "\n",
     "from deeporigin.drug_discovery import BRD_DATA_DIR, Docking, Ligand, Pocket, Protein\n",
-    "from deeporigin.drug_discovery.docking_common import resolve_docking_box_geometry\n",
-    "from deeporigin.viz.molstar_html import MOLSTAR_JS_URL\n",
+    "from deeporigin.drug_discovery.docking_common import resolve_docking_box_geometry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17f749a1",
+   "metadata": {},
+   "source": [
+    "## Protein, pocket, and ligand\n",
     "\n",
-    "\n",
-    "def _find_repo_root() -> Path:\n",
-    "    \"\"\"Return the CLI repo root whether cwd is repo root or docs/notebooks/dirty/.\"\"\"\n",
-    "    path = Path.cwd().resolve()\n",
-    "    for candidate in (path, *path.parents):\n",
-    "        if (candidate / \"pyproject.toml\").is_file() and (candidate / \"tests\").is_dir():\n",
-    "            return candidate\n",
-    "    raise FileNotFoundError(\n",
-    "        \"Could not find do-dd-client repo root. Open this notebook from the repo \"\n",
-    "        \"(repo root or docs/notebooks/dirty/).\"\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "REPO_ROOT = _find_repo_root()\n",
-    "POCKET_FIXTURE = REPO_ROOT / \"tests/fixtures/files/pocketfinder/pocket_1.pdb\"\n",
-    "\n",
-    "print(f\"Repo root: {REPO_ROOT}\")\n",
-    "print(f\"Mol* bundle: {MOLSTAR_JS_URL}\")\n",
-    "print(f\"Pocket fixture: {POCKET_FIXTURE} ({'ok' if POCKET_FIXTURE.is_file() else 'missing'})\")"
+    "The pocket is centered on the co-crystal ligand binding site. Set the initial\n",
+    "search box size before opening the interactive viewer."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b8e409b",
+   "id": "5270d87a",
    "metadata": {},
    "outputs": [],
    "source": [
     "protein = Protein.from_file(BRD_DATA_DIR / \"brd.pdb\")\n",
-    "if protein.id is None:\n",
-    "    protein.id = \"notebook-demo-protein\"\n",
+    "protein.sync()\n",
     "\n",
     "ligand = Ligand.from_sdf(BRD_DATA_DIR / \"brd-2.sdf\")\n",
-    "pocket = Pocket.from_pdb_file(str(POCKET_FIXTURE), name=\"pocket-1\")\n",
+    "\n",
+    "pocket = Pocket.from_ligand(ligand, name=\"binding-site\")\n",
     "pocket.box_size_x = pocket.box_size_y = pocket.box_size_z = 15.0\n",
     "\n",
     "box_center, box_size = resolve_docking_box_geometry(pocket)\n",
@@ -182,70 +96,74 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18e160e0",
+   "id": "b3c0e9c4",
    "metadata": {},
    "source": [
     "## Interactive box viewer\n",
     "\n",
-    "1. Run the cell below — you should see a **Mol* iframe** (not a text repr).\n",
-    "2. Use **Settings** (gear) → **Docking Box** to rotate (sliders or canvas drag).\n",
-    "3. Release the slider or mouse — the overlay should show `Synced rotation_deg=…`.\n",
-    "   That write is live in the kernel. Printed output below is not; re-run the next\n",
-    "   cell after rotating.\n"
+    "1. Run the cell below.\n",
+    "2. In Mol*, open **Settings → Docking Box**.\n",
+    "3. Resize, recenter, or rotate the box.\n",
+    "4. Release the mouse or slider.\n",
+    "5. Re-run the inspect cells below."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29b93ac4",
+   "id": "3146651d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "handle = docking.show_box(interactive=True)\n",
-    "print(f\"Bridge id: {handle.bridge_id}\")"
+    "handle = docking.show_box(interactive=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "30cbdfc7",
+   "id": "55552d4a",
    "metadata": {},
    "source": [
-    "## Inspect session rotation\n",
+    "## Inspect committed geometry\n",
     "\n",
-    "Re-run this cell after rotating. The overlay is live; this print is not."
+    "Re-run this cell after editing the box."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d6b04a5",
+   "id": "ba1f1e01",
    "metadata": {},
    "outputs": [],
    "source": [
-    "if docking.rotation_deg is None:\n",
-    "    print(\"No session rotation yet — rotate in Settings → Docking Box, then re-run this cell.\")\n",
-    "else:\n",
-    "    print(f\"rotation_deg: {docking.rotation_deg}\")\n",
+    "print(f\"Pocket center: {docking.pocket.center}\")\n",
+    "print(\n",
+    "    \"Pocket box size:\",\n",
+    "    [\n",
+    "        docking.pocket.box_size_x,\n",
+    "        docking.pocket.box_size_y,\n",
+    "        docking.pocket.box_size_z,\n",
+    "    ],\n",
+    ")\n",
+    "print(f\"rotation_deg: {docking.rotation_deg}\")\n",
     "\n",
     "if handle.committed is not None:\n",
-    "    print(f\"Last commit payload: {handle.committed}\")"
+    "    print(f\"Last commit: {handle.committed}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "06f315a7",
+   "id": "84c5cdbe",
    "metadata": {},
    "source": [
-    "## Preview tool inputs (no execution)\n",
+    "## Preview tool inputs\n",
     "\n",
-    "Shows what `docking.run()` / `docking.start()` would send in the pocket block once\n",
-    "toolbox 3.4.32+ is deployed. Does not call the platform."
+    "Shows the pocket block that `docking.run()` would send. Does not call the platform."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fc6594b",
+   "id": "e4cf5a95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,30 +173,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1118c2f3",
+   "id": "23b2b1d1",
    "metadata": {},
    "source": [
-    "## Run rotated docking (platform)\n",
+    "## Run docking (platform)\n",
     "\n",
-    "Rotate the box above first (overlay should show a non-identity `Synced rotation_deg`).\n",
-    "`run()` forwards session `rotation_deg` in the pocket block. Poses are returned in\n",
-    "the **original** protein frame (toolbox applies the inverse transform after docking).\n",
-    "\n",
-    "Optional: estimate cost before the billable run."
+    "Adjust the box above first, then re-run the inspect cells to confirm the geometry.\n",
+    "Requires `deeporigin login` and a billing-enabled org."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc30bf36",
+   "id": "c6937ef7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "if docking.rotation_deg is None:\n",
-    "    raise RuntimeError(\n",
-    "        \"Rotate the box first: Settings → Docking Box, then re-run this cell.\"\n",
-    "    )\n",
-    "\n",
     "docking.protein.upload()\n",
     "\n",
     "docking.run(quote=True)\n",
@@ -288,53 +198,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4c55d9e-b79e-45d6-82a6-5aece0f158f8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5b2adf19",
+   "id": "d7e1350d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Pocket sent to platform:\")\n",
-    "print(docking._build_tool_inputs()[0][\"pocket\"])\n",
-    "\n",
     "poses = docking.run()\n",
     "poses"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1117cb9c",
+   "id": "000c2348",
    "metadata": {},
    "source": [
     "## View docked poses\n",
     "\n",
-    "Static viewer — pose overlays are not supported in `interactive=True` mode."
+    "Pose overlays are not supported in `interactive=True` mode, so use a static viewer here."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dd9bfdf",
+   "id": "712e4c47",
    "metadata": {},
    "outputs": [],
    "source": [
     "poses.download()\n",
     "docking.show_box(poses=[poses[0]])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "09300932-0c90-45ea-90cb-0a5db1cdc92b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/drug_discovery/docking.py
+++ b/src/drug_discovery/docking.py
@@ -187,13 +187,17 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
         return list(self._rotation_deg)
 
     def _commit_docking_box(self, payload: dict[str, Any]) -> None:
-        """Store rotation from an interactive box commit payload."""
+        """Store committed docking-box geometry from the interactive viewer."""
         from deeporigin.drug_discovery.docking_common import (
             normalize_rotation_deg,
             parse_docking_box_commit,
         )
 
-        _, _, rotation_deg = parse_docking_box_commit(payload)
+        center, box_size, rotation_deg = parse_docking_box_commit(payload)
+        self.pocket.center = center
+        self.pocket.box_size_x = box_size[0]
+        self.pocket.box_size_y = box_size[1]
+        self.pocket.box_size_z = box_size[2]
         self._rotation_deg = normalize_rotation_deg(rotation_deg)
 
     @property
@@ -655,10 +659,11 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
         :meth:`run` and :meth:`start` submit to the docking tool).
 
         When ``interactive=True``, molstar ``DockingBoxControls`` are available via
-        Settings. Releasing a rotation control commits ``rotation_deg`` onto this
-        :class:`Docking` instance for subsequent :meth:`run` / :meth:`start` calls.
-        The overlay shows the last synced rotation. Static mode applies a previously
-        committed ``rotation_deg`` to the box mesh.
+        Settings. Releasing a box edit commits center/size geometry onto
+        :attr:`pocket` and commits ``rotation_deg`` onto this :class:`Docking`
+        instance for subsequent :meth:`run` / :meth:`start` calls. The overlay shows
+        the last synced geometry. Static mode applies a previously committed
+        ``rotation_deg`` to the box mesh.
 
         When ``poses`` is provided, docked ligands are overlaid as well
         (``visualizeDockedLigands`` + ``renderBoundingBox``). Interactive mode does
@@ -666,7 +671,7 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
 
         Args:
             interactive: When ``True``, enable box rotation readback via AnyWidget.
-                Session rotation updates on molstar gesture-end.
+                Box geometry updates on molstar gesture-end.
             poses: Optional docked pose(s) to overlay with the search box. Accepts a
                 :class:`Pose`, :class:`PoseSet`, :class:`Ligand`, :class:`LigandSet`,
                 or a list.

--- a/src/drug_discovery/docking_common.py
+++ b/src/drug_discovery/docking_common.py
@@ -233,8 +233,8 @@ def show_docking_box_in_notebook(
         protein: Target protein (structure downloaded locally when needed).
         pocket: Binding pocket defining the search box geometry.
         client: Optional API client for protein download.
-        interactive: When ``True``, show molstar rotation controls. Gesture-end
-            commits box orientation back to Python via AnyWidget.
+        interactive: When ``True``, show molstar box controls. Gesture-end
+            commits box geometry and rotation back to Python via AnyWidget.
         on_commit: Called with the committed payload when ``interactive=True``.
         rotation_deg: Optional session rotation to hydrate (interactive) or
             apply (static).

--- a/src/viz/molstar_html.py
+++ b/src/viz/molstar_html.py
@@ -697,8 +697,8 @@ def render_interactive_docking_box_html(
     """Build iframe HTML for an interactive protein + docking box viewer.
 
     Loads molstarLib with ``DockingBoxControls`` (via Settings). Gesture-end
-    events from ``onDockingBoxChange`` commit ``rotation_deg`` back to Python
-    through the iframe postMessage ↔ AnyWidget bridge.
+    events from ``onDockingBoxChange`` commit box geometry and ``rotation_deg``
+    back to Python through the iframe postMessage ↔ AnyWidget bridge.
 
     Args:
         pdb_path: Path to the protein PDB file on disk.
@@ -753,15 +753,52 @@ def render_interactive_docking_box_html(
     apply_rotation_js = _apply_docking_box_rotation_js()
     script_body = f"""{apply_rotation_js}
 const seedRotation = {rotation_json};
-let lastPostedRotation = Array.isArray(seedRotation)
-  ? [Number(seedRotation[0]), Number(seedRotation[1]), Number(seedRotation[2])]
-  : [0, 0, 0];
+const seedCenter = {_json_value_for_script_tag(box_center)};
+const seedSize = {_json_value_for_script_tag(box_size)};
 
-const rotationsEqual = (left, right) => {{
+const normalizeTriplet = (values) => {{
+  if (!Array.isArray(values) || values.length !== 3) {{
+    return null;
+  }}
+  return values.map((value) => Number(value));
+}};
+
+const tripletsEqual = (left, right) => {{
   if (!left || !right || left.length !== 3 || right.length !== 3) {{
     return false;
   }}
   return left.every((value, index) => Math.abs(Number(value) - Number(right[index])) < 1e-6);
+}};
+
+const normalizePayload = (payload) => {{
+  const center = normalizeTriplet(payload?.center);
+  const boxSize = normalizeTriplet(payload?.box_size);
+  const rotation = normalizeTriplet(payload?.rotation_deg) || [0, 0, 0];
+  if (!center || !boxSize) {{
+    return null;
+  }}
+  return {{
+    center,
+    box_size: boxSize,
+    rotation_deg: rotation,
+  }};
+}};
+
+let lastPostedPayload = normalizePayload({{
+  center: seedCenter,
+  box_size: seedSize,
+  rotation_deg: Array.isArray(seedRotation) ? seedRotation : [0, 0, 0],
+}});
+
+const payloadsEqual = (left, right) => {{
+  if (!left || !right) {{
+    return false;
+  }}
+  return (
+    tripletsEqual(left.center, right.center)
+    && tripletsEqual(left.box_size, right.box_size)
+    && tripletsEqual(left.rotation_deg, right.rotation_deg)
+  );
 }};
 
 const setStatus = (text, color) => {{
@@ -769,6 +806,19 @@ const setStatus = (text, color) => {{
   status.textContent = text;
   status.style.color = color;
 }};
+
+const roundTriplet = (values) => {{
+  if (!Array.isArray(values) || values.length !== 3) {{
+    return values;
+  }}
+  return values.map((value) => Number(Number(value).toFixed(2)));
+}};
+
+const formatGeometryForDisplay = (payload) => JSON.stringify({{
+  center: roundTriplet(payload.center),
+  box_size: roundTriplet(payload.box_size),
+  rotation_deg: roundTriplet(payload.rotation_deg),
+}});
 
 const payloadFromState = (state) => {{
   const rot = state.rotationDeg;
@@ -781,7 +831,7 @@ const payloadFromState = (state) => {{
 
 const postCommit = (payload) => {{
   try {{
-    lastPostedRotation = payload.rotation_deg.slice();
+    lastPostedPayload = normalizePayload(payload);
     window.parent.postMessage(
       {{
         type: {message_type_json},
@@ -791,7 +841,7 @@ const postCommit = (payload) => {{
       "*",
     );
     setStatus(
-      "Syncing rotation_deg=" + JSON.stringify(payload.rotation_deg) + "...",
+      "Syncing box geometry...",
       "#334155",
     );
   }} catch (error) {{
@@ -803,8 +853,8 @@ const onDockingBoxChange = (state) => {{
   if (!state) {{
     return;
   }}
-  const payload = payloadFromState(state);
-  if (rotationsEqual(payload.rotation_deg, lastPostedRotation)) {{
+  const payload = normalizePayload(payloadFromState(state));
+  if (!payload || payloadsEqual(payload, lastPostedPayload)) {{
     return;
   }}
   postCommit(payload);
@@ -821,8 +871,12 @@ const receiveCommitResult = (event) => {{
   }}
 
   if (data.type === {ack_message_type_json}) {{
+    const payload = normalizePayload(data.payload);
+    if (payload) {{
+      lastPostedPayload = payload;
+    }}
     setStatus(
-      "Synced rotation_deg=" + JSON.stringify(data.payload.rotation_deg),
+      "Synced box geometry: " + formatGeometryForDisplay(data.payload),
       "#334155",
     );
   }} else if (data.type === {error_message_type_json}) {{
@@ -862,7 +916,12 @@ const initViewer = async () => {{
   applyDockingBoxRotation(viewer, seedRotation);
   if (Array.isArray(seedRotation)) {{
     setStatus(
-      "Synced rotation_deg=" + JSON.stringify(lastPostedRotation),
+      "Synced box geometry: "
+      + formatGeometryForDisplay({{
+        center: seedCenter,
+        box_size: seedSize,
+        rotation_deg: seedRotation,
+      }}),
       "#334155",
     );
   }}

--- a/tests/test_docking_interactive_box.py
+++ b/tests/test_docking_interactive_box.py
@@ -18,12 +18,12 @@ from deeporigin.utils.iframe_comm_bridge import (
 )
 
 
-def test_docking_commit_docking_box_stores_rotation(
+def test_docking_commit_docking_box_stores_geometry_and_rotation(
     registered_protein,
     unregistered_pocket,
     registered_ligand,
 ) -> None:
-    """_commit_docking_box stores normalized rotation on the Docking instance."""
+    """_commit_docking_box stores committed geometry and normalized rotation."""
     docking = Docking(
         protein=registered_protein,
         pocket=unregistered_pocket,
@@ -36,24 +36,38 @@ def test_docking_commit_docking_box_stores_rotation(
             "rotation_deg": [0.0, 45.0, 0.0],
         }
     )
+    assert docking.pocket.center == [0.0, 0.0, 0.0]
+    assert docking.pocket.box_size_x == 15.0
+    assert docking.pocket.box_size_y == 15.0
+    assert docking.pocket.box_size_z == 15.0
     assert docking.rotation_deg == [0.0, 45.0, 0.0]
 
 
-def test_docking_tool_inputs_forward_rotation_deg(
+def test_docking_tool_inputs_forward_committed_geometry_and_rotation(
     client,
     registered_protein,
     unregistered_pocket,
     registered_ligand,
 ) -> None:
-    """_build_tool_inputs includes rotation_deg after interactive commit."""
+    """_build_tool_inputs includes committed geometry and rotation."""
     docking = Docking(
         protein=registered_protein,
         pocket=unregistered_pocket,
         ligand=registered_ligand,
         client=client,
     )
-    docking._rotation_deg = [0.0, 30.0, 0.0]
+    docking._commit_docking_box(
+        {
+            "center": [1.0, 2.0, 3.0],
+            "box_size": [16.0, 18.0, 20.0],
+            "rotation_deg": [0.0, 30.0, 0.0],
+        }
+    )
     params, _ = docking._build_tool_inputs()
+    assert params["pocket"]["center"] == [1.0, 2.0, 3.0]
+    assert params["pocket"]["box_size_x"] == 16.0
+    assert params["pocket"]["box_size_y"] == 18.0
+    assert params["pocket"]["box_size_z"] == 20.0
     assert params["pocket"]["rotation_deg"] == [0.0, 30.0, 0.0]
 
 
@@ -275,7 +289,7 @@ def test_render_interactive_html_with_comm_round_trips_commit() -> None:
 def test_render_interactive_docking_box_html_uses_get_docking_box(
     registered_protein,
 ) -> None:
-    """Interactive HTML commits on molstar gesture-end without an Apply button."""
+    """Interactive HTML commits geometry on molstar gesture-end."""
     from deeporigin.viz.molstar_html import render_interactive_docking_box_html
 
     protein_file = registered_protein._dump_state()
@@ -293,7 +307,8 @@ def test_render_interactive_docking_box_html_uses_get_docking_box(
     assert "proto-rot-x" not in html
     assert "Apply to notebook" not in html
     assert "do-box-apply" not in html
-    assert "Synced rotation_deg=" in html
+    assert "Syncing box geometry..." in html
+    assert "Synced box geometry:" in html
     assert "Visualization only" not in html
     assert "do-box-hint" not in html
     assert "Session rotation syncs" not in html


### PR DESCRIPTION
## Summary

Interactive docking box edits now sync full geometry back into the SDK, not just rotation. Resizing or recentering the box in Mol* updates `Pocket.center` and `Pocket.box_size_x/y/z`, and subsequent `Docking.run()` / `start()` calls send the updated pocket block to the platform. Rotation remains session-only on `Docking`.

Also refreshes the interactive demo notebook for a domain-focused walkthrough and formats overlay geometry to two decimal places.

<!-- merge-ready:auto -->
### Merge-ready status

| Item | Status |
|------|--------|
| Branch synced with base | yes (`a04d0ea`) |
| CI | PR-scoped checks green (formatting, nb-clean, build-docs, sonar); env integration jobs flaky (RCSB timeout, ADMET Failed) — unrelated to this PR |
| Non-Copilot threads | none |
| Copilot re-review | clean on `7f8436f` — 0 unresolved threads |
| Head | `7f8436f` |

_Last updated: 2026-08-19 cycle 2 complete_
<!-- /merge-ready:auto -->

## Test plan

- [x] `uv run --extra test pytest tests/test_docking_interactive_box.py tests/test_docking_common_rotation.py tests/test_docking.py -x --env local`
- [ ] Open `docs/notebooks/clean/interactive-docking-box.ipynb` via `make demo-interactive-docking-box`
- [ ] Resize/recenter/rotate the box and confirm inspect cells show updated pocket geometry and payload

Made with [Cursor](https://cursor.com)
