### PR TITLE
feat: docking box rotation support from pocket

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,19 +194,32 @@ _Avoid_: `biosim_molstar` when referring to the pip package name (`deeporigin-mo
 
 **Docking search box**:
 Wireframe of the docking tool's search extents, derived from pocket center and
-`box_size_{x,y,z}` (same geometry submitted with docking). May be rotated in
-the notebook viewer; that orientation is **session rotation**, not a property
-of the pocket. Shown via `Docking.show_box()` / `ConstrainedDocking.show_box()`.
+box sizes (same geometry submitted with docking). When pocket-finder emitted a
+nested `box`, default sizes and orientation come from **Inferred box orientation**
+; otherwise from parent lab-frame `box_size_{x,y,z}` (axis-aligned). **Session
+rotation** overrides inferred orientation in the notebook and on subsequent
+`run()` / `start()` when set. Shown via `Docking.show_box()` /
+`ConstrainedDocking.show_box()`.
 _Avoid_: pocket box; docking pocket (when meaning pocket surfaces); conflating
 with `Protein.show(pockets=...)` gaussian surfaces; treating the box as
-axis-aligned only
+always axis-aligned on new pocket-finder runs
+
+**Inferred box orientation**:
+PCA-aligned docking box rotation and OBB sizes from pocket-finder's nested
+`box` on a `Pocket` (`Pocket.box`). Distinct from **Session rotation**
+(ephemeral, gesture-committed on `Docking`). Session rotation overrides inferred
+when set. Legacy indexed pockets without `box` have no inferred orientation.
+_Avoid_: parent lab-frame `box_size_*` alone when passing orientation to docking;
+session rotation (when you mean pocket-finder output)
 
 **Session rotation**:
 Ephemeral Euler angles `[rx, ry, rz]` on a `Docking` or `ConstrainedDocking`
 instance, written by interactive `show_box` on molstar gesture-end. Not stored
-on `Pocket`. Free docking `run()` / `start()` forward it; ConstrainedDocking
-ignores it in v1. `None` when unset or identity.
-_Avoid_: Apply; pocket rotation; treating printed cell output as live
+on `Pocket`. Overrides **Inferred box orientation** when set. Free docking
+`run()` / `start()` forward it; ConstrainedDocking ignores it in v1. `None`
+when unset or identity.
+_Avoid_: Apply; pocket rotation; inferred box orientation; treating printed cell
+output as live
 
 **Box commit**:
 Kernel write of docking search-box geometry from a molstar gesture-end. Commits

--- a/docs/agents/merge-ready-lessons.md
+++ b/docs/agents/merge-ready-lessons.md
@@ -1,3 +1,11 @@
+# merge-ready lessons
+
+Notes from past merge-ready cycles. Read before starting; append after success.
+
+## 2026-08-19 — PR #607 — docking box rotation from pocket
+
+Copilot caught three real geometry edge cases on pocket-finder nested `box`: interactive commits must sync nested OBB sizes, identity rotation `[0,0,0]` must not normalize to `None` (or inferred rotation wins), and constrained docking must use parent AABB sizes when omitting `rotation_deg`. Fix all three before re-review.
+
 ## 2026-08-19 — PR #606 — interactive box geometry sync
 
 Pre-commit `nb-clean` promotion can inject `protein.sync()` into notebook setup cells; verify clean notebooks after commit when claiming “no platform sync until run”. Copilot catches this reliably — resolve before re-review.

--- a/docs/agents/merge-ready-lessons.md
+++ b/docs/agents/merge-ready-lessons.md
@@ -4,7 +4,7 @@ Notes from past merge-ready cycles. Read before starting; append after success.
 
 ## 2026-08-19 — PR #607 — docking box rotation from pocket
 
-Copilot caught three real geometry edge cases on pocket-finder nested `box`: interactive commits must sync nested OBB sizes, identity rotation `[0,0,0]` must not normalize to `None` (or inferred rotation wins), and constrained docking must use parent AABB sizes when omitting `rotation_deg`. Fix all three before re-review.
+Copilot caught three real geometry edge cases on pocket-finder nested `box`: interactive commits must sync nested OBB sizes, identity rotation `[0,0,0]` must not normalize to `None` (or inferred rotation wins), and constrained docking must use parent AABB sizes when omitting `rotation_deg`. Committed viewer sizes are OBB-local — derive parent lab-frame AABB via `abs(Rz·Ry·Rx) @ obb` only when `pocket.box` exists; legacy pockets keep OBB on parent for free docking with rotation.
 
 ## 2026-08-19 — PR #606 — interactive box geometry sync
 

--- a/docs/dd/tutorial/docking.md
+++ b/docs/dd/tutorial/docking.md
@@ -91,6 +91,13 @@ You should see something along the lines of:
 
 We can see that the protein is shown together with the identified pocket in red. 
 
+!!! tip "Oriented search box"
+    New pocket-finder runs include a nested `box` with PCA-aligned sizes and
+    `rotation_deg`. When you build a `Docking` from that pocket,
+    `show_box()` and docking runs use the inferred orientation automatically.
+    See [Interactive rotation](#rotating-the-search-box-interactively) below to
+    override it in the notebook.
+
 !!! tip "The Pocket Finder Function"
     For more details on how to use the Pocket Finder, look at [PocketFinder](../tools/pocketfinder.md).
 
@@ -100,6 +107,9 @@ Preview the docking search box (protein plus wireframe box from pocket center an
 docking = Docking(protein=protein, pocket=pocket, ligand=ligand)
 docking.show_box()
 ```
+
+When the pocket row includes nested `box` from pocket-finder, the wireframe
+defaults to that inferred orientation (PCA-aligned sizes and `rotation_deg`).
 
 To overlay docked poses with the search box (e.g. after `run()` / `get_poses()`):
 
@@ -126,6 +136,11 @@ Interactive mode requires JupyterLab with the project kernel (`make jupyter`).
 See the [Interactive docking box](../../notebooks/html/interactive-docking-box.html)
 notebook for a full walkthrough. Rotated docking on the platform requires
 toolbox docking **3.4.32+** on your org.
+
+When the pocket came from pocket-finder with a nested `box`, `show_box()` already
+applies that inferred orientation. Interactive rotation replaces it only after
+you commit a gesture (session rotation overrides inferred orientation on
+subsequent `run()` / `start()` calls).
 
 You should see something like this:
 

--- a/docs/notebooks/clean/pocket-box-inferred-orientation.ipynb
+++ b/docs/notebooks/clean/pocket-box-inferred-orientation.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Pocket-finder box → oriented docking search box\n",
+    "\n",
+    "Manual verification notebook for [DDOS-7327](https://deeporigin.atlassian.net/browse/DDOS-7327).\n",
+    "\n",
+    "Run against **dev** (`DO_ENV=dev`, `deeporigin login`). Requires pocket-finder\n",
+    "**1.6.19+** with nested `box` output (PCA OBB sizes + `rotation_deg`).\n",
+    "\n",
+    "Flow:\n",
+    "1. Sync a protein and run pocket-finder\n",
+    "2. Inspect `pocket.box` from the live run\n",
+    "3. Build `Docking(...)`, preview the oriented search box with `show_box()`\n",
+    "4. Run docking, fetch poses, and overlay them with `show_box(poses=...)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "env",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "autoreload",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from deeporigin.drug_discovery import (\n",
+    "    BRD_DATA_DIR,\n",
+    "    Docking,\n",
+    "    Ligand,\n",
+    "    PocketFinder,\n",
+    "    Protein,\n",
+    ")\n",
+    "from deeporigin.platform.client import DeepOriginClient\n",
+    "\n",
+    "client = DeepOriginClient.from_disk()\n",
+    "client.base_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "protein-md",
+   "metadata": {},
+   "source": [
+    "## Load and sync protein"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "protein",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protein = Protein.from_file(BRD_DATA_DIR / \"brd.pdb\")\n",
+    "protein.remove_water()\n",
+    "protein.sync(client=client)\n",
+    "protein.id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pf-md",
+   "metadata": {},
+   "source": [
+    "## Run pocket-finder (live dev)\n",
+    "\n",
+    "Pocket-finder emits parent lab-frame `box_size_*` plus nested `box` with\n",
+    "PCA-aligned OBB sizes and `rotation_deg`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pocket-finder",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pf = PocketFinder(protein, pocket_count=1, client=client)\n",
+    "pockets = pf.run()\n",
+    "pocket = pockets[0]\n",
+    "pocket"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inspect-md",
+   "metadata": {},
+   "source": [
+    "## Inspect nested `box`\n",
+    "\n",
+    "Confirm pocket-finder returned oriented box metadata on the `Pocket` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "inspect-box",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert pocket.box is not None, \"Expected pocket.box from pocket-finder 1.6.19+\"\n",
+    "assert \"box\" not in (pocket.props or {}), \"box should be a first-class Pocket.box field\"\n",
+    "\n",
+    "print(\"Lab-frame AABB (parent):\")\n",
+    "print(\n",
+    "    f\"  box_size_x/y/z = {pocket.box_size_x}, {pocket.box_size_y}, {pocket.box_size_z}\"\n",
+    ")\n",
+    "print(\"PCA-aligned OBB (nested box):\")\n",
+    "print(\n",
+    "    f\"  box_size_x/y/z = {pocket.box.box_size_x}, {pocket.box.box_size_y}, {pocket.box.box_size_z}\"\n",
+    ")\n",
+    "print(f\"  rotation_deg   = {pocket.box.rotation_deg}\")\n",
+    "assert len(pocket.box.rotation_deg) == 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ligand-md",
+   "metadata": {},
+   "source": [
+    "## Load ligand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ligand",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ligand = Ligand.from_sdf(BRD_DATA_DIR / \"brd-2.sdf\")\n",
+    "ligand.sync(client=client)\n",
+    "ligand.id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "docking-md",
+   "metadata": {},
+   "source": [
+    "## Build docking from pocket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "docking",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docking = Docking(\n",
+    "    protein=protein,\n",
+    "    pocket=pocket,\n",
+    "    ligand=ligand,\n",
+    "    client=client,\n",
+    ")\n",
+    "docking"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "show-box-md",
+   "metadata": {},
+   "source": [
+    "## Show oriented search box\n",
+    "\n",
+    "Static `show_box()` should render the wireframe with `pocket.box.rotation_deg`\n",
+    "already applied — verify visually that the box aligns with the pocket geometry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "show-box",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docking.show_box()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "payload-md",
+   "metadata": {},
+   "source": [
+    "## Sanity: tool payload matches viz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "payload",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params, _ = docking._build_tool_inputs()\n",
+    "pocket_in = params[\"pocket\"]\n",
+    "print(\"Tool pocket params:\")\n",
+    "print(pocket_in)\n",
+    "assert pocket_in.get(\"rotation_deg\") == docking._effective_docking_rotation_deg()\n",
+    "assert pocket_in[\"box_size_x\"] == pocket.box.box_size_x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "run-docking-md",
+   "metadata": {},
+   "source": [
+    "## Run docking\n",
+    "\n",
+    "Dock the ligand into the pocket using the oriented search box from pocket-finder.\n",
+    "This blocks until the run completes on dev."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run-docking",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docking.run(quote=True)\n",
+    "docking.estimate\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run-docking-exec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poses = docking.run()\n",
+    "poses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fetch-poses-md",
+   "metadata": {},
+   "source": [
+    "## Fetch poses\n",
+    "\n",
+    "Reload docked poses from the platform (same result as the synchronous `run()` return value)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fetch-poses",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poses = docking.get_poses(all_poses=True)\n",
+    "len(poses), poses[0].pose_score, poses[0].binding_energy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "show-poses-md",
+   "metadata": {},
+   "source": [
+    "## Show poses with oriented search box\n",
+    "\n",
+    "Overlay docked poses on the protein with the pocket-finder oriented wireframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "show-poses",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poses.download(client=client)\n",
+    "docking.show_box(poses=poses[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3eddf115-f2ef-446c-abdf-a8490f3a235a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poses.to_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40077e30-9b40-4bea-a43c-c93a9c47a9b5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/drug_discovery/constrained_docking.py
+++ b/src/drug_discovery/constrained_docking.py
@@ -622,7 +622,10 @@ class ConstrainedDocking(
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Build params and metadata for ``client.executions.create``."""
         to_dock = self.ligands if ligand_set is None else ligand_set
-        pocket_center, box_size = resolve_docking_box_geometry(self.pocket)
+        pocket_center, box_size = resolve_docking_box_geometry(
+            self.pocket,
+            use_inferred_obb=False,
+        )
         metadata = build_docking_metadata(self.protein)
         pocket_params = build_pocket_tool_params(self.pocket, pocket_center, box_size)
 

--- a/src/drug_discovery/constrained_docking.py
+++ b/src/drug_discovery/constrained_docking.py
@@ -10,9 +10,11 @@ from beartype import beartype
 from deeporigin.drug_discovery.docking_common import (
     build_docking_metadata,
     build_pocket_tool_params,
+    effective_docking_rotation_deg,
     load_docking_poses_from_execution,
     load_reference_pose_from_execution,
     resolve_docking_box_geometry,
+    resolve_pocket_docking_box,
 )
 from deeporigin.drug_discovery.execution import Execution
 from deeporigin.drug_discovery.execution_mixins import (
@@ -535,6 +537,14 @@ class ConstrainedDocking(
         _, _, rotation_deg = parse_docking_box_commit(payload)
         self._rotation_deg = normalize_rotation_deg(rotation_deg)
 
+    def _effective_docking_rotation_deg_for_viz(self) -> list[float] | None:
+        """Session rotation, else pocket-finder inferred ``box`` rotation (viz only)."""
+        _, _, inferred = resolve_pocket_docking_box(self.pocket)
+        return effective_docking_rotation_deg(
+            session=self._rotation_deg,
+            inferred=inferred,
+        )
+
     @property
     def batch_size(self) -> int:
         """Workflow batch size for async :meth:`start` (default 8)."""
@@ -856,7 +866,7 @@ class ConstrainedDocking(
             client=self.client,
             interactive=interactive,
             on_commit=self._commit_docking_box,
-            rotation_deg=self._rotation_deg,
+            rotation_deg=self._effective_docking_rotation_deg_for_viz(),
             rotation_used_by_run=False,
             poses=poses,
             height=height,

--- a/src/drug_discovery/docking.py
+++ b/src/drug_discovery/docking.py
@@ -191,16 +191,19 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
     def _commit_docking_box(self, payload: dict[str, Any]) -> None:
         """Store committed docking-box geometry from the interactive viewer."""
         from deeporigin.drug_discovery.docking_common import (
-            normalize_rotation_deg,
+            apply_committed_docking_box_geometry,
             parse_docking_box_commit,
         )
 
         center, box_size, rotation_deg = parse_docking_box_commit(payload)
-        self.pocket.center = center
-        self.pocket.box_size_x = box_size[0]
-        self.pocket.box_size_y = box_size[1]
-        self.pocket.box_size_z = box_size[2]
-        self._rotation_deg = normalize_rotation_deg(rotation_deg)
+        apply_committed_docking_box_geometry(
+            self.pocket,
+            center,
+            box_size,
+            rotation_deg,
+        )
+        # Preserve explicit identity ([0, 0, 0]) so it overrides inferred rotation.
+        self._rotation_deg = list(rotation_deg)
 
     @property
     def batch_size(self) -> int:

--- a/src/drug_discovery/docking.py
+++ b/src/drug_discovery/docking.py
@@ -9,8 +9,10 @@ import numpy as np
 from deeporigin.drug_discovery.docking_common import (
     build_docking_metadata,
     build_pocket_tool_params,
+    effective_docking_rotation_deg,
     load_docking_poses_from_execution,
     resolve_docking_box_geometry,
+    resolve_pocket_docking_box,
 )
 from deeporigin.drug_discovery.execution import Execution
 from deeporigin.drug_discovery.execution_mixins import (
@@ -379,6 +381,14 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
         """Resolve pocket center and box extents used for docking and visualization."""
         return resolve_docking_box_geometry(self.pocket)
 
+    def _effective_docking_rotation_deg(self) -> list[float] | None:
+        """Session rotation, else pocket-finder inferred ``box`` rotation."""
+        _, _, inferred = resolve_pocket_docking_box(self.pocket)
+        return effective_docking_rotation_deg(
+            session=self._rotation_deg,
+            inferred=inferred,
+        )
+
     def _build_tool_inputs(
         self, *, ligand_set: LigandSet | None = None
     ) -> tuple[dict, dict]:
@@ -403,7 +413,7 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
             self.pocket,
             pocket_center,
             box_size,
-            rotation_deg=self._rotation_deg,
+            rotation_deg=self._effective_docking_rotation_deg(),
         )
 
         params = {
@@ -655,14 +665,15 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
         """Visualize the protein with the docking search box in a Jupyter notebook.
 
         Renders the target protein and a wireframe box from :attr:`pocket` center and
-        ``box_size_x`` / ``box_size_y`` / ``box_size_z`` (same geometry as
-        :meth:`run` and :meth:`start` submit to the docking tool).
+        box sizes (same geometry as :meth:`run` and :meth:`start` submit to the
+        docking tool). When pocket-finder emitted nested ``box``, the wireframe
+        defaults to that inferred orientation unless **session rotation** is set.
 
         When ``interactive=True``, molstar ``DockingBoxControls`` are available via
         Settings. Releasing a box edit commits center/size geometry onto
         :attr:`pocket` and commits ``rotation_deg`` onto this :class:`Docking`
         instance for subsequent :meth:`run` / :meth:`start` calls. The overlay shows
-        the last synced geometry. Static mode applies a previously committed
+        the last synced geometry. Static mode applies session or inferred
         ``rotation_deg`` to the box mesh.
 
         When ``poses`` is provided, docked ligands are overlaid as well
@@ -704,7 +715,7 @@ class Docking(Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatc
             client=self.client,
             interactive=interactive,
             on_commit=self._commit_docking_box,
-            rotation_deg=self._rotation_deg,
+            rotation_deg=self._effective_docking_rotation_deg(),
             rotation_used_by_run=True,
             poses=poses,
             height=height,

--- a/src/drug_discovery/docking_common.py
+++ b/src/drug_discovery/docking_common.py
@@ -133,19 +133,51 @@ def normalize_rotation_deg(value: object) -> list[float] | None:
     return rotation
 
 
+def apply_committed_docking_box_geometry(
+    pocket: Pocket,
+    center: list[float],
+    box_size: list[float],
+    rotation_deg: list[float],
+) -> None:
+    """Write committed interactive box geometry onto pocket fields.
+
+    Updates parent ``box_size_*`` and, when present, nested ``pocket.box`` so
+    subsequent resolution sees the committed extents and rotation.
+
+    Args:
+        pocket: Binding pocket to update.
+        center: Committed box center in Angstroms.
+        box_size: Committed half-extents per axis in Angstroms.
+        rotation_deg: Committed rotation triple (identity ``[0, 0, 0]`` allowed).
+    """
+    pocket.center = center
+    pocket.box_size_x = box_size[0]
+    pocket.box_size_y = box_size[1]
+    pocket.box_size_z = box_size[2]
+    if pocket.box is not None:
+        pocket.box.box_size_x = float(box_size[0])
+        pocket.box.box_size_y = float(box_size[1])
+        pocket.box.box_size_z = float(box_size[2])
+        pocket.box.rotation_deg = list(rotation_deg)
+
+
 def resolve_pocket_docking_box(
     pocket: Pocket,
+    *,
+    use_inferred_obb: bool = True,
 ) -> tuple[list[float], list[float], list[float] | None]:
     """Resolve pocket center, box extents, and inferred rotation for docking.
 
-    When ``pocket.box`` is present (pocket-finder PCA OBB output), sizes and
-    inferred rotation come from that nested object. Legacy pockets without
-    ``box`` use parent ``box_size_*`` with no inferred rotation.
+    When ``pocket.box`` is present (pocket-finder PCA OBB output) and
+    ``use_inferred_obb`` is true, sizes and inferred rotation come from that
+    nested object. Otherwise parent ``box_size_*`` are used (lab-frame AABB).
 
     Box sizes default to ``2 * cbrt(volume)`` per axis when not set on the pocket.
 
     Args:
         pocket: Binding pocket defining the search box.
+        use_inferred_obb: When false, always use parent ``box_size_*`` even if
+            ``pocket.box`` is present. Use for tools that omit ``rotation_deg``.
 
     Returns:
         A tuple of (pocket_center, box_size, inferred_rotation_deg) where
@@ -155,7 +187,7 @@ def resolve_pocket_docking_box(
     default_box = float(2 * np.cbrt(pocket.volume or 0))
     pocket_center = pocket.get_center().tolist()
 
-    if pocket.box is not None:
+    if pocket.box is not None and use_inferred_obb:
         box = pocket.box
         box_size = [
             float(box.box_size_x),
@@ -169,7 +201,10 @@ def resolve_pocket_docking_box(
     box_size_y = pocket.box_size_y if pocket.box_size_y is not None else default_box
     box_size_z = pocket.box_size_z if pocket.box_size_z is not None else default_box
     box_size = [float(box_size_x), float(box_size_y), float(box_size_z)]
-    return pocket_center, box_size, None
+    inferred = None
+    if pocket.box is not None:
+        inferred = normalize_rotation_deg(pocket.box.rotation_deg)
+    return pocket_center, box_size, inferred
 
 
 def effective_docking_rotation_deg(
@@ -196,20 +231,30 @@ def effective_docking_rotation_deg(
     return None
 
 
-def resolve_docking_box_geometry(pocket: Pocket) -> tuple[list[float], list[float]]:
+def resolve_docking_box_geometry(
+    pocket: Pocket,
+    *,
+    use_inferred_obb: bool = True,
+) -> tuple[list[float], list[float]]:
     """Resolve pocket center and box extents for docking tool inputs.
 
     Box sizes default to ``2 * cbrt(volume)`` per axis when not set on the pocket.
-    When ``pocket.box`` is present, OBB sizes from that object are preferred.
+    When ``pocket.box`` is present and ``use_inferred_obb`` is true, OBB sizes
+    from that object are preferred.
 
     Args:
         pocket: Binding pocket defining the search box.
+        use_inferred_obb: When false, use parent lab-frame ``box_size_*`` even if
+            ``pocket.box`` is present. Required when ``rotation_deg`` is omitted.
 
     Returns:
         A tuple of (pocket_center, box_size) where each is a length-3 list of
         floats in Angstroms.
     """
-    pocket_center, box_size, _ = resolve_pocket_docking_box(pocket)
+    pocket_center, box_size, _ = resolve_pocket_docking_box(
+        pocket,
+        use_inferred_obb=use_inferred_obb,
+    )
     return pocket_center, box_size
 
 

--- a/src/drug_discovery/docking_common.py
+++ b/src/drug_discovery/docking_common.py
@@ -21,27 +21,6 @@ from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.client import DeepOriginClient
 
 
-def resolve_docking_box_geometry(pocket: Pocket) -> tuple[list[float], list[float]]:
-    """Resolve pocket center and box extents for docking tool inputs.
-
-    Box sizes default to ``2 * cbrt(volume)`` per axis when not set on the pocket.
-
-    Args:
-        pocket: Binding pocket defining the search box.
-
-    Returns:
-        A tuple of (pocket_center, box_size) where each is a length-3 list of
-        floats in Angstroms.
-    """
-    default_box = float(2 * np.cbrt(pocket.volume or 0))
-    box_size_x = pocket.box_size_x if pocket.box_size_x is not None else default_box
-    box_size_y = pocket.box_size_y if pocket.box_size_y is not None else default_box
-    box_size_z = pocket.box_size_z if pocket.box_size_z is not None else default_box
-    pocket_center = pocket.get_center().tolist()
-    box_size = [float(box_size_x), float(box_size_y), float(box_size_z)]
-    return pocket_center, box_size
-
-
 def _pose_label_for_viewer(item: Ligand | Pose, index: int) -> str:
     """Pick a LigandManager label: name → SMILES → ligand-{i}."""
     name = getattr(item, "name", None)
@@ -152,6 +131,86 @@ def normalize_rotation_deg(value: object) -> list[float] | None:
     if all(abs(angle) < 1e-9 for angle in rotation):
         return None
     return rotation
+
+
+def resolve_pocket_docking_box(
+    pocket: Pocket,
+) -> tuple[list[float], list[float], list[float] | None]:
+    """Resolve pocket center, box extents, and inferred rotation for docking.
+
+    When ``pocket.box`` is present (pocket-finder PCA OBB output), sizes and
+    inferred rotation come from that nested object. Legacy pockets without
+    ``box`` use parent ``box_size_*`` with no inferred rotation.
+
+    Box sizes default to ``2 * cbrt(volume)`` per axis when not set on the pocket.
+
+    Args:
+        pocket: Binding pocket defining the search box.
+
+    Returns:
+        A tuple of (pocket_center, box_size, inferred_rotation_deg) where
+        ``inferred_rotation_deg`` is a length-3 list or ``None`` when absent or
+        identity.
+    """
+    default_box = float(2 * np.cbrt(pocket.volume or 0))
+    pocket_center = pocket.get_center().tolist()
+
+    if pocket.box is not None:
+        box = pocket.box
+        box_size = [
+            float(box.box_size_x),
+            float(box.box_size_y),
+            float(box.box_size_z),
+        ]
+        inferred_rotation = normalize_rotation_deg(box.rotation_deg)
+        return pocket_center, box_size, inferred_rotation
+
+    box_size_x = pocket.box_size_x if pocket.box_size_x is not None else default_box
+    box_size_y = pocket.box_size_y if pocket.box_size_y is not None else default_box
+    box_size_z = pocket.box_size_z if pocket.box_size_z is not None else default_box
+    box_size = [float(box_size_x), float(box_size_y), float(box_size_z)]
+    return pocket_center, box_size, None
+
+
+def effective_docking_rotation_deg(
+    *,
+    session: list[float] | None,
+    inferred: list[float] | None,
+) -> list[float] | None:
+    """Pick rotation for docking viz and tool inputs.
+
+    Session rotation from interactive ``show_box`` overrides pocket-finder
+    inferred orientation when set.
+
+    Args:
+        session: Ephemeral rotation on ``Docking`` / ``ConstrainedDocking``.
+        inferred: Rotation from ``pocket.box.rotation_deg`` when present.
+
+    Returns:
+        Effective rotation triple, or ``None`` when neither source applies.
+    """
+    if session is not None:
+        return list(session)
+    if inferred is not None:
+        return list(inferred)
+    return None
+
+
+def resolve_docking_box_geometry(pocket: Pocket) -> tuple[list[float], list[float]]:
+    """Resolve pocket center and box extents for docking tool inputs.
+
+    Box sizes default to ``2 * cbrt(volume)`` per axis when not set on the pocket.
+    When ``pocket.box`` is present, OBB sizes from that object are preferred.
+
+    Args:
+        pocket: Binding pocket defining the search box.
+
+    Returns:
+        A tuple of (pocket_center, box_size) where each is a length-3 list of
+        floats in Angstroms.
+    """
+    pocket_center, box_size, _ = resolve_pocket_docking_box(pocket)
+    return pocket_center, box_size
 
 
 def parse_docking_box_commit(
@@ -271,7 +330,7 @@ def show_docking_box_in_notebook(
     )
 
     protein_file = protein._dump_state()
-    pocket_center, box_size = resolve_docking_box_geometry(pocket)
+    pocket_center, box_size, _ = resolve_pocket_docking_box(pocket)
 
     if interactive:
         if get_notebook_environment() != "jupyter":

--- a/src/drug_discovery/docking_common.py
+++ b/src/drug_discovery/docking_common.py
@@ -191,15 +191,19 @@ def apply_committed_docking_box_geometry(
     """
     pocket.center = center
     obb_extents = [float(value) for value in box_size]
-    lab_extents = lab_frame_aabb_extents_from_obb(obb_extents, rotation_deg)
-    pocket.box_size_x = lab_extents[0]
-    pocket.box_size_y = lab_extents[1]
-    pocket.box_size_z = lab_extents[2]
     if pocket.box is not None:
         pocket.box.box_size_x = obb_extents[0]
         pocket.box.box_size_y = obb_extents[1]
         pocket.box.box_size_z = obb_extents[2]
         pocket.box.rotation_deg = list(rotation_deg)
+        lab_extents = lab_frame_aabb_extents_from_obb(obb_extents, rotation_deg)
+        pocket.box_size_x = lab_extents[0]
+        pocket.box_size_y = lab_extents[1]
+        pocket.box_size_z = lab_extents[2]
+    else:
+        pocket.box_size_x = obb_extents[0]
+        pocket.box_size_y = obb_extents[1]
+        pocket.box_size_z = obb_extents[2]
 
 
 def resolve_pocket_docking_box(

--- a/src/drug_discovery/docking_common.py
+++ b/src/drug_discovery/docking_common.py
@@ -133,6 +133,45 @@ def normalize_rotation_deg(value: object) -> list[float] | None:
     return rotation
 
 
+def _euler_rotation_matrix_deg(rotation_deg: list[float]) -> np.ndarray:
+    """Build lab←local rotation matrix (Rz·Ry·Rx) from Euler degrees.
+
+    Matches molstar ``DockingBoxManager.setRotation(rx, ry, rz)`` ordering.
+    """
+    rx, ry, rz = (math.radians(value) for value in rotation_deg)
+    cx, sx = math.cos(rx), math.sin(rx)
+    cy, sy = math.cos(ry), math.sin(ry)
+    cz, sz = math.cos(rz), math.sin(rz)
+    rot_x = np.array([[1.0, 0.0, 0.0], [0.0, cx, -sx], [0.0, sx, cx]])
+    rot_y = np.array([[cy, 0.0, sy], [0.0, 1.0, 0.0], [-sy, 0.0, cy]])
+    rot_z = np.array([[cz, -sz, 0.0], [sz, cz, 0.0], [0.0, 0.0, 1.0]])
+    return rot_z @ rot_y @ rot_x
+
+
+def lab_frame_aabb_extents_from_obb(
+    obb_extents: list[float],
+    rotation_deg: list[float],
+) -> list[float]:
+    """Derive lab-frame AABB extents from local OBB extents and rotation.
+
+    Committed viewer ``box_size`` values are local (OBB) extents. Parent
+    ``box_size_*`` fields store lab-frame AABB extents for tools that omit
+    ``rotation_deg`` (e.g. constrained docking v1).
+
+    Args:
+        obb_extents: Local box dimensions ``[sx, sy, sz]`` in Angstroms.
+        rotation_deg: Euler rotation ``[rx, ry, rz]`` in degrees (Rz·Ry·Rx).
+
+    Returns:
+        Lab-frame axis-aligned box dimensions along X/Y/Z.
+    """
+    if all(abs(angle) < 1e-9 for angle in rotation_deg):
+        return [float(value) for value in obb_extents]
+    rotation = _euler_rotation_matrix_deg(rotation_deg)
+    obb = np.asarray(obb_extents, dtype=float)
+    return (np.abs(rotation) @ obb).tolist()
+
+
 def apply_committed_docking_box_geometry(
     pocket: Pocket,
     center: list[float],
@@ -151,13 +190,15 @@ def apply_committed_docking_box_geometry(
         rotation_deg: Committed rotation triple (identity ``[0, 0, 0]`` allowed).
     """
     pocket.center = center
-    pocket.box_size_x = box_size[0]
-    pocket.box_size_y = box_size[1]
-    pocket.box_size_z = box_size[2]
+    obb_extents = [float(value) for value in box_size]
+    lab_extents = lab_frame_aabb_extents_from_obb(obb_extents, rotation_deg)
+    pocket.box_size_x = lab_extents[0]
+    pocket.box_size_y = lab_extents[1]
+    pocket.box_size_z = lab_extents[2]
     if pocket.box is not None:
-        pocket.box.box_size_x = float(box_size[0])
-        pocket.box.box_size_y = float(box_size[1])
-        pocket.box.box_size_z = float(box_size[2])
+        pocket.box.box_size_x = obb_extents[0]
+        pocket.box.box_size_y = obb_extents[1]
+        pocket.box.box_size_z = obb_extents[2]
         pocket.box.rotation_deg = list(rotation_deg)
 
 

--- a/src/drug_discovery/structures/pocket.py
+++ b/src/drug_discovery/structures/pocket.py
@@ -23,6 +23,16 @@ from deeporigin.platform.client import DeepOriginClient
 
 
 @dataclass
+class PocketBox:
+    """PCA-aligned docking box fragment from pocket-finder ``box`` output."""
+
+    box_size_x: float
+    box_size_y: float
+    box_size_z: float
+    rotation_deg: list[float]
+
+
+@dataclass
 class Pocket(Entity):
     """Class representing a binding pocket in a protein structure.
 
@@ -52,6 +62,7 @@ class Pocket(Entity):
     box_size_x: Optional[float] = None
     box_size_y: Optional[float] = None
     box_size_z: Optional[float] = None
+    box: Optional[PocketBox] = None
 
     pocket_count: Optional[int] = None
     pocket_min_size: Optional[int] = None
@@ -328,12 +339,24 @@ class Pocket(Entity):
         if all(
             v is not None for v in (self.box_size_x, self.box_size_y, self.box_size_z)
         ):
+            box_label = "Box size" if self.box is None else "Box size (lab frame)"
             table_data.append(
                 [
-                    "Box size",
+                    box_label,
                     f"{self.box_size_x:.2f} \u00d7 {self.box_size_y:.2f} \u00d7 {self.box_size_z:.2f} \u00c5",
                 ]
             )
+
+        if self.box is not None:
+            box = self.box
+            table_data.append(
+                [
+                    "Docking box size",
+                    f"{box.box_size_x:.2f} \u00d7 {box.box_size_y:.2f} \u00d7 {box.box_size_z:.2f} \u00c5",
+                ]
+            )
+            rx, ry, rz = box.rotation_deg
+            table_data.append(["rotation_deg", f"({rx:.2f}, {ry:.2f}, {rz:.2f})"])
 
         property_rows = [
             ("Volume", self.volume, " \u00c5\u00b3"),
@@ -473,6 +496,75 @@ class Pocket(Entity):
         "polar_apolar_SASA_ratio": "polar_apolar_sasa_ratio",
         "pocket_center": "center",
     }
+
+    @classmethod
+    def _parse_box(cls, entry: dict[str, Any]) -> PocketBox | None:
+        """Parse nested pocket-finder ``box`` output when present.
+
+        Args:
+            entry: Single pocket dict from pocket-finder jobOutputs or result-explorer.
+
+        Returns:
+            A :class:`PocketBox` when ``entry`` contains a valid ``box`` object,
+            otherwise ``None``.
+
+        Raises:
+            ValueError: If ``box`` is present but missing required fields or has
+                invalid types.
+        """
+        raw = entry.get("box")
+        if raw is None:
+            return None
+        if not isinstance(raw, dict):
+            raise ValueError(f"pocket box must be an object, got {raw!r}")
+
+        missing = [
+            key
+            for key in ("box_size_x", "box_size_y", "box_size_z", "rotation_deg")
+            if key not in raw
+        ]
+        if missing:
+            raise ValueError(
+                f"pocket box missing required field(s): {', '.join(missing)}"
+            )
+
+        try:
+            box_size_x = float(raw["box_size_x"])
+            box_size_y = float(raw["box_size_y"])
+            box_size_z = float(raw["box_size_z"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"pocket box box_size_* must be numbers, got {raw!r}"
+            ) from exc
+
+        rotation_raw = raw["rotation_deg"]
+        if not isinstance(rotation_raw, list) or len(rotation_raw) != 3:
+            raise ValueError(
+                f"pocket box rotation_deg must be a length-3 list, got {rotation_raw!r}"
+            )
+        try:
+            rotation_deg = [float(value) for value in rotation_raw]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"pocket box rotation_deg must contain numbers, got {rotation_raw!r}"
+            ) from exc
+
+        sizes = (box_size_x, box_size_y, box_size_z)
+        if not all(np.isfinite(size) and size > 0 for size in sizes):
+            raise ValueError(
+                f"pocket box box_size_* must be positive finite numbers, got {raw!r}"
+            )
+        if not all(np.isfinite(angle) for angle in rotation_deg):
+            raise ValueError(
+                f"pocket box rotation_deg must be finite numbers, got {rotation_raw!r}"
+            )
+
+        return PocketBox(
+            box_size_x=box_size_x,
+            box_size_y=box_size_y,
+            box_size_z=box_size_z,
+            rotation_deg=rotation_deg,
+        )
 
     @staticmethod
     def _path_points_to_existing_local_file(path: str) -> bool:
@@ -631,6 +723,7 @@ class Pocket(Entity):
                 "remote_path",
                 "protein_id",
                 "project_id",
+                "box",
             }
             | cls._PROPERTY_ATTRS
             | json_mapped_keys
@@ -654,6 +747,8 @@ class Pocket(Entity):
                 if json_key in entry and attr_name not in attr_kwargs:
                     attr_kwargs[attr_name] = entry[json_key]
 
+            parsed_box = cls._parse_box(entry)
+
             props = {k: v for k, v in entry.items() if k not in reserved_keys}
 
             project_id: str | None = entry.get("project_id")
@@ -670,6 +765,7 @@ class Pocket(Entity):
                 props=props,
                 color=colors[idx % len(colors)],
                 _client=client,
+                box=parsed_box,
                 **attr_kwargs,
             )
             pockets.append(pocket)

--- a/tests/fixtures/tool-runs/deeporigin.pocketfinder/run.json
+++ b/tests/fixtures/tool-runs/deeporigin.pocketfinder/run.json
@@ -244,6 +244,12 @@
                     -4.9440002,
                     15.457001
                 ],
+                "box": {
+                    "box_size_x": 22.0,
+                    "box_size_y": 20.0,
+                    "box_size_z": 21.0,
+                    "rotation_deg": [5.0, 10.0, 15.0]
+                },
                 "pocket_count": 1,
                 "pocket_min_size": 30,
                 "polar_SASA": 309.8629,

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -7,12 +7,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from deeporigin.drug_discovery import BRD_DATA_DIR
 from deeporigin.drug_discovery.docking import (
     Docking,
     _docking_default_name,
     _ligand_tool_input_row,
 )
 from deeporigin.drug_discovery.structures.ligand import Ligand, LigandSet
+from deeporigin.drug_discovery.structures.pocket import Pocket
 from deeporigin.drug_discovery.structures.pose import Pose, PoseSet
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.constants import (
@@ -270,6 +272,79 @@ def test_show_box_empty_poses_raises(
 
     with pytest.raises(ValueError, match="non-empty"):
         docking.show_box(poses=[])
+
+
+def _pocket_with_box_fixture() -> Pocket:
+    brd_pdb = Path(BRD_DATA_DIR) / "brd.pdb"
+    return Pocket.from_json(
+        [
+            {
+                "file_path": str(brd_pdb),
+                "protein_id": "prot_1",
+                "volume": 300.0,
+                "pocket_center": [1.0, 2.0, 3.0],
+                "box_size_x": 25.0,
+                "box_size_y": 24.0,
+                "box_size_z": 25.0,
+                "box": {
+                    "box_size_x": 22.0,
+                    "box_size_y": 20.0,
+                    "box_size_z": 21.0,
+                    "rotation_deg": [5.0, 10.0, 15.0],
+                },
+            }
+        ]
+    )[0]
+
+
+def test_build_tool_inputs_includes_inferred_rotation_from_box(
+    client,
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """_build_tool_inputs forwards pocket.box rotation_deg when session is unset."""
+    pocket = _pocket_with_box_fixture()
+    docking = Docking(
+        protein=registered_protein,
+        pocket=pocket,
+        ligand=registered_ligand,
+        client=client,
+    )
+
+    params, _ = docking._build_tool_inputs()
+
+    assert params["pocket"]["box_size_x"] == 22.0
+    assert params["pocket"]["box_size_y"] == 20.0
+    assert params["pocket"]["box_size_z"] == 21.0
+    assert params["pocket"]["rotation_deg"] == [5.0, 10.0, 15.0]
+
+
+def test_show_box_forwards_inferred_rotation_from_box(
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """show_box seeds wireframe rotation from pocket.box when session is unset."""
+    pocket = _pocket_with_box_fixture()
+    docking = Docking(
+        protein=registered_protein,
+        pocket=pocket,
+        ligand=registered_ligand,
+    )
+    mock_builder = MagicMock(return_value="<html>box</html>")
+
+    with (
+        patch(
+            "deeporigin.viz.molstar_html.render_docking_box_html",
+            mock_builder,
+        ),
+        patch(
+            "deeporigin.utils.notebook.render_html",
+            side_effect=lambda html, **kwargs: html,
+        ),
+    ):
+        docking.show_box()
+
+    assert mock_builder.call_args.kwargs["rotation_deg"] == [5.0, 10.0, 15.0]
 
 
 def test_docking_accepts_single_ligand(

--- a/tests/test_docking_box_fragment.py
+++ b/tests/test_docking_box_fragment.py
@@ -74,3 +74,25 @@ def test_effective_docking_rotation_deg_uses_inferred_when_session_unset() -> No
 def test_effective_docking_rotation_deg_none_when_both_absent() -> None:
     """No rotation when neither session nor inferred orientation is available."""
     assert effective_docking_rotation_deg(session=None, inferred=None) is None
+
+
+def test_effective_docking_rotation_deg_identity_session_overrides_inferred() -> None:
+    """Explicit identity session rotation suppresses pocket-finder inferred angle."""
+    assert effective_docking_rotation_deg(
+        session=[0.0, 0.0, 0.0],
+        inferred=[5.0, 10.0, 15.0],
+    ) == [0.0, 0.0, 0.0]
+
+
+def test_resolve_pocket_docking_box_parent_aabb_when_obb_disabled() -> None:
+    """Parent lab-frame sizes apply when inferred OBB resolution is disabled."""
+    pocket = Pocket.from_json([_POCKET_WITH_BOX])[0]
+
+    center, box_size, inferred = resolve_pocket_docking_box(
+        pocket,
+        use_inferred_obb=False,
+    )
+
+    assert center == pytest.approx([1.0, 2.0, 3.0])
+    assert box_size == pytest.approx([25.0, 24.0, 25.0])
+    assert inferred == pytest.approx([5.0, 10.0, 15.0])

--- a/tests/test_docking_box_fragment.py
+++ b/tests/test_docking_box_fragment.py
@@ -1,0 +1,76 @@
+"""Tests for pocket-finder ``box`` consumption in docking_common."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from deeporigin.drug_discovery import BRD_DATA_DIR, Pocket
+from deeporigin.drug_discovery.docking_common import (
+    effective_docking_rotation_deg,
+    resolve_pocket_docking_box,
+)
+
+_BRD_PDB = Path(os.path.join(BRD_DATA_DIR, "brd.pdb"))
+
+_POCKET_WITH_BOX = {
+    "file_path": str(_BRD_PDB),
+    "protein_id": "prot_1",
+    "volume": 300.0,
+    "pocket_center": [1.0, 2.0, 3.0],
+    "box_size_x": 25.0,
+    "box_size_y": 24.0,
+    "box_size_z": 25.0,
+    "box": {
+        "box_size_x": 22.0,
+        "box_size_y": 20.0,
+        "box_size_z": 21.0,
+        "rotation_deg": [5.0, 10.0, 15.0],
+    },
+}
+
+
+def test_resolve_pocket_docking_box_prefers_nested_box() -> None:
+    """resolve_pocket_docking_box uses OBB sizes and inferred rotation from box."""
+    pocket = Pocket.from_json([_POCKET_WITH_BOX])[0]
+
+    center, box_size, inferred = resolve_pocket_docking_box(pocket)
+
+    assert center == pytest.approx([1.0, 2.0, 3.0])
+    assert box_size == pytest.approx([22.0, 20.0, 21.0])
+    assert inferred == pytest.approx([5.0, 10.0, 15.0])
+
+
+def test_resolve_pocket_docking_box_legacy_without_box(
+    unregistered_pocket,
+) -> None:
+    """Legacy pockets without box use parent sizes and no inferred rotation."""
+    center, box_size, inferred = resolve_pocket_docking_box(unregistered_pocket)
+
+    assert len(center) == 3
+    assert len(box_size) == 3
+    assert all(size > 0 for size in box_size)
+    assert inferred is None
+
+
+def test_effective_docking_rotation_deg_prefers_session() -> None:
+    """Session rotation overrides pocket-finder inferred orientation."""
+    assert effective_docking_rotation_deg(
+        session=[0.0, 45.0, 0.0],
+        inferred=[5.0, 10.0, 15.0],
+    ) == [0.0, 45.0, 0.0]
+
+
+def test_effective_docking_rotation_deg_uses_inferred_when_session_unset() -> None:
+    """Inferred rotation applies when session rotation is unset."""
+    assert effective_docking_rotation_deg(
+        session=None,
+        inferred=[5.0, 10.0, 15.0],
+    ) == [5.0, 10.0, 15.0]
+
+
+def test_effective_docking_rotation_deg_none_when_both_absent() -> None:
+    """No rotation when neither session nor inferred orientation is available."""
+    assert effective_docking_rotation_deg(session=None, inferred=None) is None

--- a/tests/test_docking_common_rotation.py
+++ b/tests/test_docking_common_rotation.py
@@ -4,6 +4,7 @@ import pytest
 
 from deeporigin.drug_discovery.docking_common import (
     build_pocket_tool_params,
+    lab_frame_aabb_extents_from_obb,
     normalize_rotation_deg,
     parse_docking_box_commit,
 )
@@ -75,3 +76,20 @@ def test_build_pocket_tool_params_omits_identity_rotation(
         rotation_deg=[0.0, 0.0, 0.0],
     )
     assert "rotation_deg" not in params
+
+
+def test_lab_frame_aabb_extents_from_obb_y_rotation() -> None:
+    """45° Y rotation expands lab-frame X/Z AABB from local OBB extents."""
+    aabb = lab_frame_aabb_extents_from_obb([22.0, 20.0, 21.0], [0.0, 45.0, 0.0])
+    assert aabb[0] == pytest.approx(30.405, rel=1e-3)
+    assert aabb[1] == pytest.approx(20.0)
+    assert aabb[2] == pytest.approx(30.405, rel=1e-3)
+
+
+def test_lab_frame_aabb_extents_identity_is_unchanged() -> None:
+    """Identity rotation leaves OBB extents unchanged in lab frame."""
+    assert lab_frame_aabb_extents_from_obb([10.0, 11.0, 12.0], [0.0, 0.0, 0.0]) == [
+        10.0,
+        11.0,
+        12.0,
+    ]

--- a/tests/test_docking_interactive_box.py
+++ b/tests/test_docking_interactive_box.py
@@ -39,9 +39,9 @@ def test_docking_commit_docking_box_stores_geometry_and_rotation(
         }
     )
     assert docking.pocket.center == [0.0, 0.0, 0.0]
-    assert docking.pocket.box_size_x == pytest.approx(21.213, rel=1e-3)
+    assert docking.pocket.box_size_x == 15.0
     assert docking.pocket.box_size_y == 15.0
-    assert docking.pocket.box_size_z == pytest.approx(21.213, rel=1e-3)
+    assert docking.pocket.box_size_z == 15.0
     assert docking.rotation_deg == [0.0, 45.0, 0.0]
 
 

--- a/tests/test_docking_interactive_box.py
+++ b/tests/test_docking_interactive_box.py
@@ -6,9 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
+from deeporigin.drug_discovery import BRD_DATA_DIR
 from deeporigin.drug_discovery.constrained_docking import ConstrainedDocking
 from deeporigin.drug_discovery.docking import Docking
 from deeporigin.drug_discovery.structures.ligand import Ligand
+from deeporigin.drug_discovery.structures.pocket import Pocket
 from deeporigin.utils.iframe_comm_bridge import (
     _WIDGET_ESM,
     DOCKING_BOX_COMMIT_ACK_MESSAGE_TYPE,
@@ -69,6 +71,82 @@ def test_docking_tool_inputs_forward_committed_geometry_and_rotation(
     assert params["pocket"]["box_size_y"] == 18.0
     assert params["pocket"]["box_size_z"] == 20.0
     assert params["pocket"]["rotation_deg"] == [0.0, 30.0, 0.0]
+
+
+def _pocket_with_box_fixture() -> Pocket:
+    brd_pdb = Path(BRD_DATA_DIR) / "brd.pdb"
+    return Pocket.from_json(
+        [
+            {
+                "file_path": str(brd_pdb),
+                "protein_id": "prot_1",
+                "volume": 300.0,
+                "pocket_center": [1.0, 2.0, 3.0],
+                "box_size_x": 25.0,
+                "box_size_y": 24.0,
+                "box_size_z": 25.0,
+                "box": {
+                    "box_size_x": 22.0,
+                    "box_size_y": 20.0,
+                    "box_size_z": 21.0,
+                    "rotation_deg": [5.0, 10.0, 15.0],
+                },
+            }
+        ]
+    )[0]
+
+
+def test_session_rotation_overrides_inferred_on_tool_inputs(
+    client,
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """Committed session rotation wins over pocket.box inferred orientation."""
+    docking = Docking(
+        protein=registered_protein,
+        pocket=_pocket_with_box_fixture(),
+        ligand=registered_ligand,
+        client=client,
+    )
+    docking._rotation_deg = [0.0, 45.0, 0.0]
+
+    params, _ = docking._build_tool_inputs()
+
+    assert params["pocket"]["rotation_deg"] == [0.0, 45.0, 0.0]
+
+
+def test_show_box_interactive_session_overrides_inferred_rotation(
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """Interactive show_box uses session rotation instead of pocket.box default."""
+    docking = Docking(
+        protein=registered_protein,
+        pocket=_pocket_with_box_fixture(),
+        ligand=registered_ligand,
+    )
+    docking._rotation_deg = [0.0, 45.0, 0.0]
+    handle = IframeCommHandle(bridge_id="test-bridge")
+
+    with (
+        patch(
+            "deeporigin.utils.notebook.get_notebook_environment",
+            return_value="jupyter",
+        ),
+        patch(
+            "deeporigin.utils.iframe_comm_bridge.render_interactive_html_with_comm",
+            return_value=handle,
+        ) as mock_bridge,
+        patch(
+            "deeporigin.viz.molstar_html.render_interactive_docking_box_html",
+            return_value="<html></html>",
+        ) as mock_html,
+    ):
+        docking.show_box(interactive=True)
+        html_builder = mock_bridge.call_args.args[0]
+        html_builder("bridge-id")
+
+    assert mock_html.call_args.kwargs["rotation_deg"] == [0.0, 45.0, 0.0]
 
 
 def test_constrained_docking_tool_inputs_omit_rotation_deg(

--- a/tests/test_docking_interactive_box.py
+++ b/tests/test_docking_interactive_box.py
@@ -115,6 +115,97 @@ def test_session_rotation_overrides_inferred_on_tool_inputs(
     assert params["pocket"]["rotation_deg"] == [0.0, 45.0, 0.0]
 
 
+def test_commit_updates_nested_box_sizes(
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """Interactive size commits sync nested pocket.box extents."""
+    pocket = _pocket_with_box_fixture()
+    docking = Docking(
+        protein=registered_protein,
+        pocket=pocket,
+        ligand=registered_ligand,
+    )
+    docking._commit_docking_box(
+        {
+            "center": [1.0, 2.0, 3.0],
+            "box_size": [18.0, 19.0, 20.0],
+            "rotation_deg": [5.0, 10.0, 15.0],
+        }
+    )
+
+    assert pocket.box is not None
+    assert pocket.box.box_size_x == 18.0
+    assert pocket.box.box_size_y == 19.0
+    assert pocket.box.box_size_z == 20.0
+
+    params, _ = docking._build_tool_inputs()
+    assert params["pocket"]["box_size_x"] == 18.0
+    assert params["pocket"]["box_size_y"] == 19.0
+    assert params["pocket"]["box_size_z"] == 20.0
+
+
+def test_identity_rotation_commit_overrides_inferred(
+    client,
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """Resetting rotation to identity suppresses pocket-finder inferred angle."""
+    docking = Docking(
+        protein=registered_protein,
+        pocket=_pocket_with_box_fixture(),
+        ligand=registered_ligand,
+        client=client,
+    )
+    docking._commit_docking_box(
+        {
+            "center": [1.0, 2.0, 3.0],
+            "box_size": [22.0, 20.0, 21.0],
+            "rotation_deg": [0.0, 0.0, 0.0],
+        }
+    )
+
+    assert docking.rotation_deg == [0.0, 0.0, 0.0]
+    params, _ = docking._build_tool_inputs()
+    assert "rotation_deg" not in params["pocket"]
+
+
+def test_constrained_docking_uses_parent_aabb_for_nested_box(
+    client,
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """Constrained docking v1 uses lab-frame sizes when rotation is omitted."""
+    from tests.test_constrained_docking import _make_reference_pair
+
+    reference_ligand, reference_pose = _make_reference_pair()
+    reference_ligand.remote_path = "testing/brd-2.sdf"
+    reference_ligand.id = "brd-2"
+    reference_pose.remote_path = "testing/docked-pose.sdf"
+    reference_pose.id = "brd-2-pose"
+
+    test_a = Ligand.from_smiles("CCO")
+    test_a.id = "test-a"
+    test_b = Ligand.from_smiles("CC(C)O")
+    test_b.id = "test-b"
+
+    constrained = ConstrainedDocking(
+        protein=registered_protein,
+        pocket=_pocket_with_box_fixture(),
+        reference_ligand=reference_ligand,
+        reference_pose=reference_pose,
+        ligands=[test_a, test_b],
+        client=client,
+    )
+
+    params, _ = constrained._build_tool_inputs()
+
+    assert params["pocket"]["box_size_x"] == 25.0
+    assert params["pocket"]["box_size_y"] == 24.0
+    assert params["pocket"]["box_size_z"] == 25.0
+    assert "rotation_deg" not in params["pocket"]
+
+
 def test_show_box_interactive_session_overrides_inferred_rotation(
     registered_protein,
     registered_ligand,

--- a/tests/test_docking_interactive_box.py
+++ b/tests/test_docking_interactive_box.py
@@ -39,9 +39,9 @@ def test_docking_commit_docking_box_stores_geometry_and_rotation(
         }
     )
     assert docking.pocket.center == [0.0, 0.0, 0.0]
-    assert docking.pocket.box_size_x == 15.0
+    assert docking.pocket.box_size_x == pytest.approx(21.213, rel=1e-3)
     assert docking.pocket.box_size_y == 15.0
-    assert docking.pocket.box_size_z == 15.0
+    assert docking.pocket.box_size_z == pytest.approx(21.213, rel=1e-3)
     assert docking.rotation_deg == [0.0, 45.0, 0.0]
 
 
@@ -203,6 +203,56 @@ def test_constrained_docking_uses_parent_aabb_for_nested_box(
     assert params["pocket"]["box_size_x"] == 25.0
     assert params["pocket"]["box_size_y"] == 24.0
     assert params["pocket"]["box_size_z"] == 25.0
+    assert "rotation_deg" not in params["pocket"]
+
+
+def test_constrained_docking_uses_lab_aabb_after_rotated_commit(
+    client,
+    registered_protein,
+    registered_ligand,
+) -> None:
+    """Constrained docking reads lab-frame AABB after a rotated interactive commit."""
+    from tests.test_constrained_docking import _make_reference_pair
+
+    reference_ligand, reference_pose = _make_reference_pair()
+    reference_ligand.remote_path = "testing/brd-2.sdf"
+    reference_ligand.id = "brd-2"
+    reference_pose.remote_path = "testing/docked-pose.sdf"
+    reference_pose.id = "brd-2-pose"
+
+    test_a = Ligand.from_smiles("CCO")
+    test_a.id = "test-a"
+    test_b = Ligand.from_smiles("CC(C)O")
+    test_b.id = "test-b"
+
+    pocket = _pocket_with_box_fixture()
+    Docking(
+        protein=registered_protein,
+        pocket=pocket,
+        ligand=registered_ligand,
+        client=client,
+    )._commit_docking_box(
+        {
+            "center": [1.0, 2.0, 3.0],
+            "box_size": [22.0, 20.0, 21.0],
+            "rotation_deg": [0.0, 45.0, 0.0],
+        }
+    )
+
+    constrained = ConstrainedDocking(
+        protein=registered_protein,
+        pocket=pocket,
+        reference_ligand=reference_ligand,
+        reference_pose=reference_pose,
+        ligands=[test_a, test_b],
+        client=client,
+    )
+
+    params, _ = constrained._build_tool_inputs()
+
+    assert params["pocket"]["box_size_x"] == pytest.approx(30.405, rel=1e-3)
+    assert params["pocket"]["box_size_y"] == pytest.approx(20.0)
+    assert params["pocket"]["box_size_z"] == pytest.approx(30.405, rel=1e-3)
     assert "rotation_deg" not in params["pocket"]
 
 

--- a/tests/test_pocket.py
+++ b/tests/test_pocket.py
@@ -129,6 +129,84 @@ def test_from_json_platform_file_path_is_remote_lazy_lv0():
     assert "pocket_min_size" not in (pocket.props or {})
 
 
+def test_from_json_parses_nested_box_lv0():
+    """Nested pocket-finder box is stored on Pocket.box, not in props."""
+    data = [
+        {
+            "file_path": str(_BRD_PDB),
+            "protein_id": "prot_1",
+            "volume": 300.0,
+            "pocket_center": [1.0, 2.0, 3.0],
+            "box_size_x": 25.0,
+            "box_size_y": 24.0,
+            "box_size_z": 25.0,
+            "box": {
+                "box_size_x": 22.0,
+                "box_size_y": 20.0,
+                "box_size_z": 21.0,
+                "rotation_deg": [5.0, 10.0, 15.0],
+            },
+        }
+    ]
+
+    pocket = Pocket.from_json(data)[0]
+
+    assert pocket.box is not None
+    assert pocket.box.box_size_x == pytest.approx(22.0)
+    assert pocket.box.box_size_y == pytest.approx(20.0)
+    assert pocket.box.box_size_z == pytest.approx(21.0)
+    assert pocket.box.rotation_deg == pytest.approx([5.0, 10.0, 15.0])
+    assert pocket.box_size_x == pytest.approx(25.0)
+    assert "box" not in (pocket.props or {})
+
+
+def test_from_json_legacy_without_box_has_none_box_lv0():
+    """Legacy pocket rows without box leave Pocket.box unset."""
+    data = [
+        {
+            "file_path": str(_BRD_PDB),
+            "protein_id": "prot_1",
+            "volume": 42.0,
+            "box_size_x": 14.0,
+            "box_size_y": 19.0,
+            "box_size_z": 20.0,
+        }
+    ]
+
+    pocket = Pocket.from_json(data)[0]
+
+    assert pocket.box is None
+
+
+def test_pocket_repr_includes_rotation_deg_when_box_present_lv0():
+    """Pocket repr shows nested box rotation_deg and OBB sizes."""
+    data = [
+        {
+            "file_path": str(_BRD_PDB),
+            "protein_id": "prot_1",
+            "volume": 300.0,
+            "pocket_center": [1.0, 2.0, 3.0],
+            "box_size_x": 25.0,
+            "box_size_y": 24.0,
+            "box_size_z": 25.0,
+            "box": {
+                "box_size_x": 22.0,
+                "box_size_y": 20.0,
+                "box_size_z": 21.0,
+                "rotation_deg": [5.0, 10.0, 15.0],
+            },
+        }
+    ]
+
+    text = repr(Pocket.from_json(data)[0])
+
+    assert "rotation_deg" in text
+    assert "5.00" in text
+    assert "10.00" in text
+    assert "15.00" in text
+    assert "Docking box size" in text
+
+
 def test_from_json_id_is_set_lv0():
     """When an 'id' key is present it should populate the Pocket.id attribute."""
     data = [{"id": "pocket-abc-123", "file_path": str(_BRD_PDB)}]


### PR DESCRIPTION
## Summary

Adds support for pocket-finder's PCA-aligned nested `box` orientation on docking search boxes — inferred rotation from `Pocket.box` is used by default in `show_box()` and `run()`/`start()`, with session rotation overriding when set interactively.

**Jira:** [DDOS-7327](https://deeporigin.atlassian.net/browse/DDOS-7327)

## Test plan

- [ ] `Docking`/`ConstrainedDocking` use `pocket.box.rotation_deg` when session rotation unset
- [ ] Session rotation still overrides inferred orientation on `run()`/`start()`
- [ ] Interactive commits sync sizes/rotation to nested `pocket.box`
- [ ] Identity rotation reset (`[0,0,0]`) suppresses inferred orientation
- [ ] Constrained docking uses parent AABB sizes (no rotation in tool payload)
- [ ] CI green (Ubuntu functionality + formatting required)

<!-- merge-ready:auto -->
### Merge-ready status

_Auto-updated — cycle 3 complete, last updated: 2026-08-19T18:14:00Z_

| Check | Status |
|-------|--------|
| Branch vs `main` | ✅ synced at `14744c6` |
| Head | `3d0273b` |
| CI | ✅ required green (Ubuntu 3.12, formatting, docs, nb-clean, Sonar, Semgrep); 3.13 RCSB flake |
| Copilot | ✅ reviewed `3d0273b`, 0 open threads |
| Review threads | 0 human/Bugbot, 0 Copilot |
| Human approval | ⏳ REVIEW_REQUIRED |

**Recent activity**
- Cycle 3: lab-frame AABB derivation for nested-box commits; legacy pockets keep OBB on parent.
- All Copilot geometry threads resolved across 3 cycles.
- CI rerun: Ubuntu 3.12 green; 3.13 failed on RCSB PDB timeout (unrelated flake).
<!-- /merge-ready:auto -->


[DDOS-7327]: https://deeporigin.atlassian.net/browse/DDOS-7327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ