### PR TITLE
fix(viz): hide controls in static docking boxes (DDOS-7327)

### DIFF
--- a/docs/notebooks/clean/pocket-box-inferred-orientation.ipynb
+++ b/docs/notebooks/clean/pocket-box-inferred-orientation.ipynb
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docking.show_box()"
+    "docking.show_box(interactive=True)"
    ]
   },
   {
@@ -225,6 +225,16 @@
     "print(pocket_in)\n",
     "assert pocket_in.get(\"rotation_deg\") == docking._effective_docking_rotation_deg()\n",
     "assert pocket_in[\"box_size_x\"] == pocket.box.box_size_x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6425df4f-872d-4259-92f6-301086256ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docking.rotation_deg"
    ]
   },
   {
@@ -256,8 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "poses = docking.run()\n",
-    "poses"
+    "poses = docking.run()"
    ]
   },
   {
@@ -277,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "poses = docking.get_poses(all_poses=True)\n",
+    "poses = docking.get_poses()\n",
     "len(poses), poses[0].pose_score, poses[0].binding_energy"
    ]
   },

--- a/docs/notebooks/clean/pocket-box-inferred-orientation.ipynb
+++ b/docs/notebooks/clean/pocket-box-inferred-orientation.ipynb
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docking.show_box(interactive=True)"
+    "docking.show_box()"
    ]
   },
   {
@@ -225,16 +225,6 @@
     "print(pocket_in)\n",
     "assert pocket_in.get(\"rotation_deg\") == docking._effective_docking_rotation_deg()\n",
     "assert pocket_in[\"box_size_x\"] == pocket.box.box_size_x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6425df4f-872d-4259-92f6-301086256ee6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "docking.rotation_deg"
    ]
   },
   {
@@ -266,7 +256,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "poses = docking.run()"
+    "poses = docking.run()\n",
+    "poses"
    ]
   },
   {
@@ -286,7 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "poses = docking.get_poses()\n",
+    "poses = docking.get_poses(all_poses=True)\n",
     "len(poses), poses[0].pose_score, poses[0].binding_energy"
    ]
   },

--- a/src/viz/molstar_html.py
+++ b/src/viz/molstar_html.py
@@ -663,7 +663,9 @@ const initViewer = async () => {{
       if (typeof molstarLib === "undefined" || typeof molstarLib.initViewer !== "function") {{
         throw new Error("molstarLib bundle did not load from {MOLSTAR_JS_URL}");
       }}
-      const viewer = await molstarLib.initViewer("{_VIEWER_CONTAINER_ID}");
+      const viewer = await molstarLib.initViewer("{_VIEWER_CONTAINER_ID}", {{
+        showDockingBoxControls: false,
+      }});
       const proteinData = atob("{pdb_b64}");
       const structureRef = await viewer.api.loadFromRawContent(
         proteinData,
@@ -1081,7 +1083,9 @@ const initViewer = async () => {{
       if (typeof molstarLib === "undefined" || typeof molstarLib.initViewer !== "function") {{
         throw new Error("molstarLib bundle did not load from {MOLSTAR_JS_URL}");
       }}
-      const viewer = await molstarLib.initViewer("{_VIEWER_CONTAINER_ID}");
+      const viewer = await molstarLib.initViewer("{_VIEWER_CONTAINER_ID}", {{
+        showDockingBoxControls: false,
+      }});
       const proteinData = atob("{pdb_b64}");
       const ligandPayloads = {ligands_json};
       {decode_ligands}

--- a/tests/test_docking_interactive_box.py
+++ b/tests/test_docking_interactive_box.py
@@ -528,6 +528,7 @@ def test_render_interactive_docking_box_html_uses_get_docking_box(
     assert "do-box-apply" not in html
     assert "Syncing box geometry..." in html
     assert "Synced box geometry:" in html
+    assert "showDockingBoxControls: false" not in html
     assert "Visualization only" not in html
     assert "do-box-hint" not in html
     assert "Session rotation syncs" not in html

--- a/tests/test_molstar_html.py
+++ b/tests/test_molstar_html.py
@@ -282,6 +282,7 @@ def test_render_docking_box_html_api() -> None:
     assert "[12.0, 23.0, 34.0]" in html
     assert "0.2" in html
     assert str(0xFFFF00) in html
+    assert "showDockingBoxControls: false" in html
 
 
 def test_render_docking_box_html_applies_rotation_deg() -> None:
@@ -363,6 +364,7 @@ def test_render_protein_with_box_and_poses_html_api() -> None:
     assert "[8.0, 17.0, 26.0]" in html
     assert "[12.0, 23.0, 34.0]" in html
     assert str(0xFFFF00) in html
+    assert "showDockingBoxControls: false" in html
 
 
 def test_render_protein_with_box_and_poses_html_applies_rotation_deg() -> None:


### PR DESCRIPTION
## Summary

- Request a read-only Mol* docking box viewer for static `show_box()` renders and pose overlays.
- Preserve editing and Python synchronization for `show_box(interactive=True)`.
- Prevent visual-only edits that look committed but cannot reach Python.

Depends on [platform-ui#1490](https://github.com/deeporiginbio/platform-ui/pull/1490) and its hosted Mol* bundle deployment.

**Jira:** [DDOS-7327](https://deeporigin.atlassian.net/browse/DDOS-7327)

## Test plan

- [x] `uv run --extra lint ruff format src/viz/molstar_html.py tests/test_molstar_html.py tests/test_docking_interactive_box.py`
- [x] `uv run --extra lint ruff check --select I src/viz/molstar_html.py tests/test_molstar_html.py tests/test_docking_interactive_box.py --fix`
- [x] `uv run --extra test --extra core --extra tools --extra plots pytest --env local -x tests/test_molstar_html.py tests/test_docking_interactive_box.py -q` (43 passed)

Made with [Cursor](https://cursor.com)

[DDOS-7327]: https://deeporigin.atlassian.net/browse/DDOS-7327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ