### PR TITLE
fix(ligand): keep organic parent instead of SaltRemover remnant (DDOS-7357)

### DIFF
--- a/docs/dd/how-to/ligands.md
+++ b/docs/dd/how-to/ligands.md
@@ -336,7 +336,7 @@ ligands.show_grid()
 
 ### Preparing Ligands
 
-You can prepare a ligand for downstream workflows using the `prepare()` method. This performs salt removal, kekulization, fragment validation (rejects multiple non-identical fragments), and validates atom types:
+You can prepare a ligand for downstream workflows using the `prepare()` method. This selects an organic parent when the input is an unambiguous salt (organic fragment plus inorganic counterions), kekulizes, validates fragments (rejects multiple non-identical fragments), and validates atom types. Coordination complexes without an organic parent (for example cisplatin) are left unstripped:
 
 === "Ligand"
 

--- a/docs/dd/ref/ligand.md
+++ b/docs/dd/ref/ligand.md
@@ -31,7 +31,7 @@ Until molprops has been run or the platform record has pinned values, these fiel
 
 Use `Ligand.prepare()` to perform common preparation steps before docking:
 
-- salt removal, kekulization
+- organic-parent selection (counterion stripping when unambiguous), kekulization
 - fragment validation (rejects multiple non-identical fragments)
 - validation of atom symbols against supported types
 

--- a/src/drug_discovery/structures/ligand.py
+++ b/src/drug_discovery/structures/ligand.py
@@ -19,11 +19,7 @@ import pandas as pd
 from rdkit import Chem, RDLogger
 from rdkit.Chem import AllChem, rdMolDescriptors
 
-from deeporigin.drug_discovery.constants import (
-    LIGANDS_DIR,
-    METAL_ELEMENTS,
-    SUPPORTED_ATOM_SYMBOLS,
-)
+from deeporigin.drug_discovery.constants import LIGANDS_DIR, SUPPORTED_ATOM_SYMBOLS
 from deeporigin.drug_discovery.validation import validate_fragments
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.client import DeepOriginClient
@@ -43,13 +39,6 @@ FILE_FORMATS = Literal["mol", "mol2", "pdb", "pdbqt", "xyz", "sdf"]
 def _fragment_has_carbon(mol: Chem.Mol) -> bool:
     """Return True if ``mol`` contains at least one carbon atom."""
     return any(atom.GetAtomicNum() == 6 for atom in mol.GetAtoms())
-
-
-def _is_lone_metal_ion(mol: Chem.Mol) -> bool:
-    """Return True if ``mol`` is a single metal heavy atom (e.g. ``[Zn+2]``)."""
-    if mol.GetNumHeavyAtoms() != 1:
-        return False
-    return mol.GetAtomWithIdx(0).GetSymbol().upper() in METAL_ELEMENTS
 
 
 def choose_parent_mol(mol: Chem.Mol) -> Chem.Mol:
@@ -73,15 +62,7 @@ def choose_parent_mol(mol: Chem.Mol) -> Chem.Mol:
 
     organic = [frag for frag in frags if _fragment_has_carbon(frag)]
     if len(organic) == 1:
-        parent = organic[0]
-        if _is_lone_metal_ion(parent):
-            warnings.warn(
-                "Refusing to normalize to a lone metal ion; keeping all fragments.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return mol
-        return parent
+        return organic[0]
 
     # Multiple organics, or no organic parent (e.g. cisplatin): do not strip.
     return mol
@@ -771,12 +752,15 @@ class Ligand(Entity):
         Raises:
             DeepOriginException: If parent selection or kekulization fails
         """
-        before = Chem.MolToSmiles(Chem.RemoveHs(self.mol), canonical=True)
-        parent = choose_parent_mol(self.mol)
-        if parent is None:
-            raise DeepOriginException("Parent fragment selection failed.")
+        try:
+            before = Chem.MolToSmiles(Chem.RemoveHs(self.mol), canonical=True)
+            parent = choose_parent_mol(self.mol)
+            after = Chem.MolToSmiles(Chem.RemoveHs(parent), canonical=True)
+        except DeepOriginException:
+            raise
+        except Exception as e:
+            raise DeepOriginException(f"Parent fragment selection failed: {e}") from e
 
-        after = Chem.MolToSmiles(Chem.RemoveHs(parent), canonical=True)
         if after != before:
             warnings.warn(
                 f"Normalized multi-fragment ligand from {before!r} to {after!r}.",

--- a/src/drug_discovery/structures/ligand.py
+++ b/src/drug_discovery/structures/ligand.py
@@ -17,9 +17,13 @@ from beartype import beartype
 import numpy as np
 import pandas as pd
 from rdkit import Chem, RDLogger
-from rdkit.Chem import AllChem, SaltRemover, rdMolDescriptors
+from rdkit.Chem import AllChem, rdMolDescriptors
 
-from deeporigin.drug_discovery.constants import LIGANDS_DIR, SUPPORTED_ATOM_SYMBOLS
+from deeporigin.drug_discovery.constants import (
+    LIGANDS_DIR,
+    METAL_ELEMENTS,
+    SUPPORTED_ATOM_SYMBOLS,
+)
 from deeporigin.drug_discovery.validation import validate_fragments
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.client import DeepOriginClient
@@ -34,6 +38,54 @@ RDLogger.DisableLog("rdApp.*")  # ty:ignore[unresolved-attribute]
 
 
 FILE_FORMATS = Literal["mol", "mol2", "pdb", "pdbqt", "xyz", "sdf"]
+
+
+def _fragment_has_carbon(mol: Chem.Mol) -> bool:
+    """Return True if ``mol`` contains at least one carbon atom."""
+    return any(atom.GetAtomicNum() == 6 for atom in mol.GetAtoms())
+
+
+def _is_lone_metal_ion(mol: Chem.Mol) -> bool:
+    """Return True if ``mol`` is a single metal heavy atom (e.g. ``[Zn+2]``)."""
+    if mol.GetNumHeavyAtoms() != 1:
+        return False
+    return mol.GetAtomWithIdx(0).GetSymbol().upper() in METAL_ELEMENTS
+
+
+def choose_parent_mol(mol: Chem.Mol) -> Chem.Mol:
+    """Select the parent structure from a possibly multi-fragment molecule.
+
+    Prefers a single carbon-containing (organic) fragment over inorganic
+    counterions. Multi-fragment inputs with no organic parent (for example
+    coordination complexes like cisplatin) or with multiple organic fragments
+    are left unchanged so callers do not silently lose ligands or mixtures.
+
+    Args:
+        mol: RDKit molecule, possibly with disconnected fragments.
+
+    Returns:
+        The chosen parent molecule, or ``mol`` unchanged when stripping would
+        be ambiguous or unsafe.
+    """
+    frags = Chem.GetMolFrags(mol, asMols=True, sanitizeFrags=True)
+    if len(frags) <= 1:
+        return mol
+
+    organic = [frag for frag in frags if _fragment_has_carbon(frag)]
+    if len(organic) == 1:
+        parent = organic[0]
+        if _is_lone_metal_ion(parent):
+            warnings.warn(
+                "Refusing to normalize to a lone metal ion; keeping all fragments.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return mol
+        return parent
+
+    # Multiple organics, or no organic parent (e.g. cisplatin): do not strip.
+    return mol
+
 
 # Keys returned by ``deeporigin.mol-props-combined`` rows → Ligand attribute
 # names (snake_case). Mirrors the ``molprops[*]`` items in the combined tool's
@@ -709,23 +761,35 @@ class Ligand(Entity):
 
     def process_mol(self) -> None:
         """
-        Clean the ligand molecule by removing hydrogens and sanitizing the structure.
+        Clean the ligand molecule by selecting an organic parent and kekulizing.
+
+        When the input has a single carbon-containing fragment plus inorganic
+        counterions, the organic parent is kept. Coordination complexes and
+        multi-organic mixtures are left unchanged. Emits a :class:`UserWarning`
+        when the kept structure differs from the input.
 
         Raises:
-            DeepOriginException: If salt removal or kekulization fails
+            DeepOriginException: If parent selection or kekulization fails
         """
-        remover = SaltRemover.SaltRemover()
+        before = Chem.MolToSmiles(Chem.RemoveHs(self.mol), canonical=True)
+        parent = choose_parent_mol(self.mol)
+        if parent is None:
+            raise DeepOriginException("Parent fragment selection failed.")
 
-        stripped_mol = remover.StripMol(self.mol)
-        if stripped_mol is None:
-            raise DeepOriginException("Salt removal failed.")
+        after = Chem.MolToSmiles(Chem.RemoveHs(parent), canonical=True)
+        if after != before:
+            warnings.warn(
+                f"Normalized multi-fragment ligand from {before!r} to {after!r}.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         try:
-            Chem.Kekulize(stripped_mol, clearAromaticFlags=False)
+            Chem.Kekulize(parent, clearAromaticFlags=False)
         except Chem.KekulizeException as e:
             raise DeepOriginException("Kekulization failed.") from e
 
-        self.mol = stripped_mol
+        self.mol = parent
 
     def unsupported_atom_symbols(self) -> list[str]:
         """Sorted unique atom symbols in :attr:`mol` not in ``SUPPORTED_ATOM_SYMBOLS``."""
@@ -745,7 +809,7 @@ class Ligand(Entity):
         """Prepare the ligand for downstream workflows.
 
         The routine performs the following using RDKit and internal utilities:
-        - Salt removal
+        - Organic-parent selection (counterion stripping when unambiguous)
         - Kekulization
         - Fragment validation (rejects multiple non-identical fragments)
         - Wildcard atom validation (rejects '*' atoms)
@@ -763,7 +827,7 @@ class Ligand(Entity):
                                multiple non-identical fragments are detected.
         """
         # Start from current molecule
-        # 1) Salt removal and kekulization (reuse process_mol)
+        # 1) Organic-parent selection and kekulization (reuse process_mol)
         self.process_mol()
 
         # 2) Fragment validation
@@ -964,6 +1028,8 @@ class Ligand(Entity):
         Pass a molecule via the keyword argument ``mol`` (see class factories such as
         :meth:`from_smiles` and :meth:`from_rdkit_mol`).
         """
+        # Record the caller-supplied structure before parent-fragment selection.
+        initial_smiles = Chem.MolToSmiles(Chem.RemoveHs(self.mol), canonical=True)
 
         self.process_mol()
         self.smiles = Chem.MolToSmiles(Chem.RemoveHs(self.mol), canonical=True)
@@ -973,7 +1039,7 @@ class Ligand(Entity):
 
         self.set_conformer_id()
 
-        self.mol.SetProp("initial_smiles", Chem.MolToSmiles(Chem.RemoveHs(self.mol)))
+        self.mol.SetProp("initial_smiles", initial_smiles)
 
         if self.name is None:
             self.name = "Unknown_Ligand"
@@ -2574,7 +2640,7 @@ class LigandSet:
         Prepare all ligands in the set for downstream workflows.
 
         This calls the prepare() method on each Ligand in the set, which performs:
-        - Salt removal
+        - Organic-parent selection (counterion stripping when unambiguous)
         - Kekulization
         - Fragment validation (rejects multiple non-identical fragments)
         - Validation of atom types against supported symbols

--- a/tests/test_ligand.py
+++ b/tests/test_ligand.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import tempfile
 import uuid
+import warnings
 
 import numpy as np
 import pytest
@@ -381,7 +382,7 @@ def test_ligand_mol_from_file_formats(file_type):
 
 # Test instance methods
 def test_ligand_process_mol():
-    """Test the process_mol method for salt removal and kekulization"""
+    """Test the process_mol method for parent selection and kekulization"""
 
     # Create a simple molecule
     ligand = Ligand.from_smiles("CCO", name="Ethanol")
@@ -392,7 +393,7 @@ def test_ligand_process_mol():
 
 
 def test_ligand_prepare_basic():
-    """Prepare should salt-strip, kekulize, and validate atom types"""
+    """Prepare should select parent, kekulize, and validate atom types"""
 
     ligand = Ligand.from_smiles("CCO", name="Ethanol")
     # Ensure prepare runs and sets properties
@@ -404,6 +405,60 @@ def test_ligand_prepare_basic():
     assert all(a in SUPPORTED_ATOM_SYMBOLS for a in ligand.atom_types)
     # Prepared attribute
     assert ligand.prepared, "Ligand should be prepared"
+
+
+@pytest.mark.parametrize(
+    ("smiles", "expected_smiles", "expect_warning"),
+    [
+        # DDOS-7357: organic acid + metal — keep the organic parent, not the metal
+        ("CC(=O)[O-].[Zn+2]", "CC(=O)[O-]", True),
+        # DDOS-7357: coordination complex — do not strip ammine ligands
+        ("N.N.Cl[Pt]Cl", "N.N.Cl[Pt]Cl", False),
+        # DDOS-7357: single organic fragment — unchanged
+        ("CC(=O)Oc1ccccc1C(=O)O", "CC(=O)Oc1ccccc1C(=O)O", False),
+        # Classic pharmaceutical salt — keep organic parent
+        ("CC(=O)O.[Na+]", "CC(=O)O", True),
+        ("c1ccccc1.Cl", "c1ccccc1", True),
+    ],
+)
+def test_ligand_from_smiles_organic_parent_selection(
+    smiles: str,
+    expected_smiles: str,
+    expect_warning: bool,
+) -> None:
+    """Construction keeps the organic parent, not catalogue salt leftovers."""
+    from rdkit import Chem
+
+    expected_canonical = Chem.MolToSmiles(
+        Chem.MolFromSmiles(expected_smiles), canonical=True
+    )
+    if expect_warning:
+        with pytest.warns(UserWarning, match="Normalized multi-fragment"):
+            ligand = Ligand.from_smiles(smiles)
+    else:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ligand = Ligand.from_smiles(smiles)
+        assert not any(
+            issubclass(w.category, UserWarning)
+            and "Normalized multi-fragment" in str(w.message)
+            for w in caught
+        )
+
+    assert ligand.smiles == expected_canonical
+    assert ligand.mol.GetProp("initial_smiles") == Chem.MolToSmiles(
+        Chem.MolFromSmiles(smiles), canonical=True
+    )
+
+
+def test_ligand_cisplatin_retains_ammine_and_platinum() -> None:
+    """Cisplatin must keep N and Pt after construction (DDOS-7357)."""
+    ligand = Ligand.from_smiles("N.N.Cl[Pt]Cl")
+    symbols = {atom.GetSymbol() for atom in ligand.mol.GetAtoms()}
+    assert "N" in symbols
+    assert "Pt" in symbols
+    assert "Cl" in symbols
+    assert ligand.mol.GetNumAtoms() == 5
 
 
 def test_ligand_prepare_remove_hydrogens():


### PR DESCRIPTION
## Summary

- Replace RDKit `SaltRemover` in `Ligand.process_mol` with organic-parent selection so metal salts (e.g. zinc acetate) keep the drug fragment rather than the counterion.
- Leave coordination complexes without an organic parent (e.g. cisplatin) unstripped; warn when normalization changes the molecule; record pre-strip SMILES in `initial_smiles`.
- Add DDOS-7357 regression tests and update ligand prep docs.

**Jira:** [DDOS-7357](https://deeporigin.atlassian.net/browse/DDOS-7357)


[DDOS-7357]: https://deeporigin.atlassian.net/browse/DDOS-7357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ