### PR TITLE
fix(test): redirect Windows home in blocked_home fixture

### DIFF
--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -17,9 +17,14 @@ def _blocked_home(tmp_path: pathlib.Path) -> pathlib.Path:
 def blocked_home(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> pathlib.Path:
-    """Point HOME at a path whose parent cannot be created implicitly."""
+    """Point the user home at a path whose parent cannot be created implicitly."""
     home = _blocked_home(tmp_path)
     monkeypatch.setenv("HOME", str(home))
+    # ntpath.expanduser ignores HOME: it reads USERPROFILE, then HOMEDRIVE +
+    # HOMEPATH. Patch those too so Path.home() is redirected on Windows.
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
     return home
 
 


### PR DESCRIPTION
## Problem

The Windows leg of `functionality-tests` has been failing:

```
FAILED tests/test_import_side_effects.py::test_import_config_does_not_create_deeporigin_dir
AssertionError: assert WindowsPath('C:/Users/runneradmin/.deeporigin/config.json')
  == .../pytest-0/test_import_config_does_not_cr0/missing/home/.deeporigin/config.json
```

([failing job](https://github.com/deeporiginbio/do-dd-client/actions/runs/32793771350/job/97640757148))

## Cause

`Path.home()` goes through `os.path.expanduser("~")`, and on Windows that is `ntpath.expanduser`, which **never reads `HOME`** — it resolves `~` from `USERPROFILE`, falling back to `HOMEDRIVE` + `HOMEPATH`.

The `blocked_home` fixture only patched `HOME`, so on Windows `deeporigin.config.CONFIG_JSON_LOCATION` still pointed at the real `C:/Users/runneradmin/.deeporigin`, and the assertion failed. The companion test `test_import_platform_client_does_not_create_deeporigin_dir` passed only vacuously for the same reason — the tmp dir was never a candidate for creation.

## Fix

Patch `USERPROFILE` alongside `HOME` and drop `HOMEDRIVE`/`HOMEPATH`, so the fixture redirects the home directory on every platform. Both tests now exercise what they intend on Windows too.

Verified locally on macOS (`uv run pytest tests/test_import_side_effects.py --env local` → 2 passed); Windows verification is the CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)