### PR TITLE
feat(drug-discovery): ProteinPrep v2 with loops-off run() (DDOS-7371)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
         "bioinformatics",
         "cbrt",
         "cheminformatics",
+        "cofactor",
         "cofactors",
         "CONECT",
         "dataclass",

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,23 +54,33 @@ _Avoid_: "system" alone when meaning the prepared molecular system artifact
 
 **Protein Prep**:
 Platform tool `deeporigin.protein-prep` that inventories a caller-supplied
-protein (`action=recommend`) then applies a frozen Selection and protonation
-(`action=prepare`). Loop modelling runs on prepare unless the caller sets
-loops-off prepare. CLI class `ProteinPrep`: `ProteinPrep(protein).start()` is
-recommend; `.start()` is always legal. `.run()` is loops-off prepare only and
-must be `method: direct` (fail loud otherwise). Recommend is always direct and
-is not a `.run()` path.
+protein, records editable keep/review/skip decisions, then applies resolved
+keep/skip decisions and protonation. CLI class `ProteinPrep` is one preparation
+session: `.recommend()` updates its Selection without binding its execution id;
+`.run()` or `.start()` submits durable preparation and permanently binds the
+object. `protein` is constructor-only. Loop modelling runs unless the caller
+sets loops-off prepare.
 _Avoid_: SystemPrep / FEP assembly; quoting this tool (billing is skipped);
-v1 keep/remove lists (`keep_chain_ids`, …); treating loops-off as skipping
-recommend or Selection; `watch()` on a `.run()` / sync execution; `inputs.sync`
+public `action`; a separate recommend object; silently converting `review` to
+`skip`; v1 keep/remove lists (`keep_chain_ids`, …); treating loops-off as
+skipping Protein Prep; `watch()` on a `.run()` / sync execution; `inputs.sync`
 on protein-prep (not in the tool schema)
+
+**Protein Prep Selection**:
+Digest-bound component decision map produced by `ProteinPrep.recommend()` or
+provided by the caller. Editable SDK state may contain `keep`, `review`, or
+`skip`; durable preparation requires every `review` to be resolved. `keep()` and
+`skip()` change only named component ids.
+_Avoid_: silently resolving `review`; treating a Selection as analyzer evidence
+(that is the recommendation)
 
 **Loops-off prepare**:
 Protein Prep `action=prepare` with `model_missing_loops=false`: apply the
 frozen Selection (keep/skip chains, waters, ligands, cofactors), skip loop
 modelling, still protonate. Quoted `method: direct`; `pdb_id` optional.
-_Avoid_: skipping Protein Prep; skipping protonation; constructing
-`ProteinPrep(protein, model_missing_loops=False)` (illegal on recommend)
+CLI `.run()` blocks and returns the prepared Protein; `.start()` is also valid.
+_Avoid_: skipping Protein Prep; skipping protonation; treating loops-off as
+requiring synchronous SDK use
 
 **Prepared protein (CLI)**:
 In-memory :class:`~deeporigin.drug_discovery.structures.protein.Protein` returned

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,25 +54,57 @@ _Avoid_: "system" alone when meaning the prepared molecular system artifact
 
 **Protein Prep**:
 Platform tool `deeporigin.protein-prep` that inventories a caller-supplied
-protein, records editable keep/review/skip decisions, then applies resolved
-keep/skip decisions and protonation. CLI class `ProteinPrep` is one preparation
-session: `.recommend()` updates its Selection without binding its execution id;
-`.run()` or `.start()` submits durable preparation and permanently binds the
-object. `protein` is constructor-only. Loop modelling runs unless the caller
-sets loops-off prepare.
+protein, records editable keep/review/skip Decisions, then applies resolved
+keep/skip Decisions and protonation. CLI class `ProteinPrep` is one preparation
+session: `.recommend()` updates its Selection without binding its execution id
+and returns the Recommendation view; `.run()` or `.start()` submits durable
+preparation and permanently binds the object. `protein` is constructor-only.
+Loop modelling runs unless the caller sets loops-off prepare.
 _Avoid_: SystemPrep / FEP assembly; quoting this tool (billing is skipped);
 public `action`; a separate recommend object; silently converting `review` to
 `skip`; v1 keep/remove lists (`keep_chain_ids`, …); treating loops-off as
 skipping Protein Prep; `watch()` on a `.run()` / sync execution; `inputs.sync`
-on protein-prep (not in the tool schema)
+on protein-prep (not in the tool schema); treating `.recommendation` as a raw
+dict or a pandas DataFrame type
 
 **Protein Prep Selection**:
-Digest-bound component decision map produced by `ProteinPrep.recommend()` or
+Digest-bound component Decision map produced by `ProteinPrep.recommend()` or
 provided by the caller. Editable SDK state may contain `keep`, `review`, or
 `skip`; durable preparation requires every `review` to be resolved. `keep()` and
-`skip()` change only named component ids.
+`skip()` set Decisions for listed component ids, or for every Component matching
+keyword filters (`kind`, `subtype`, `decision`). Filters are equivalent to
+passing the matching ids. Positional ids and keyword filters are mutually
+exclusive. Both methods return the `ProteinPrep`.
 _Avoid_: silently resolving `review`; treating a Selection as analyzer evidence
-(that is the recommendation)
+(that is the Component recommendation); treating matcher kwargs as a different
+operation from listing ids; mixing ids with matcher kwargs; `pp.recommend().keep()`
+(recommend returns the Recommendation view, not the `ProteinPrep`)
+
+**Component** (Protein Prep):
+One inventoried chain, ligand, cofactor, or water from recommend. Identity is
+the component `id` (for example `chain:A`, `water:A:HOH:310:`).
+_Avoid_: residue when you mean a Component; treating `label` as the id
+
+**Component recommendation**:
+The analyzer's frozen keep, review, or skip tag on a Component. It does not
+change when the caller edits Decisions.
+_Avoid_: Decision; the analyzer payload as a whole
+
+**Decision**:
+The caller's current keep, review, or skip value for a Component in the
+Selection. Edited by `keep()` / `skip()`. Preparation requires every Decision
+to be keep or skip.
+_Avoid_: `recommendation` when you mean the live Selection value; Component
+recommendation
+
+**Recommendation view**:
+Callable notebook table of Components on `ProteinPrep.recommendation` after
+recommend (also returned by `.recommend()`). Columns include frozen Component
+recommendation and live Decision. Calling it AND-filters (`kind`, `subtype`,
+`recommendation`, `decision`) and returns a DataFrame. Unset is `None`. `.raw`
+is the analyzer payload. Not mapping-like (`["components"]` is gone).
+_Avoid_: returning a DataFrame from the property itself; dict access on the view;
+`keep` / `skip` on the view (`pp.recommend().keep()` is not supported)
 
 **Loops-off prepare**:
 Protein Prep `action=prepare` with `model_missing_loops=false`: apply the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,10 +53,24 @@ Simulation-ready binding and solvation XML files (and metadata) produced by syst
 _Avoid_: "system" alone when meaning the prepared molecular system artifact
 
 **Protein Prep**:
-Platform tool `deeporigin.protein-prep` that cleans a caller-supplied protein
-structure (explicit keep/remove lists, loop modelling, protonation). CLI class
-`ProteinPrep` is async-only (`start()`, not `run()`).
-_Avoid_: SystemPrep / FEP assembly; quoting this tool (billing is skipped)
+Platform tool `deeporigin.protein-prep` that inventories a caller-supplied
+protein (`action=recommend`) then applies a frozen Selection and protonation
+(`action=prepare`). Loop modelling runs on prepare unless the caller sets
+loops-off prepare. CLI class `ProteinPrep`: `ProteinPrep(protein).start()` is
+recommend; `.start()` is always legal. `.run()` is loops-off prepare only and
+must be `method: direct` (fail loud otherwise). Recommend is always direct and
+is not a `.run()` path.
+_Avoid_: SystemPrep / FEP assembly; quoting this tool (billing is skipped);
+v1 keep/remove lists (`keep_chain_ids`, …); treating loops-off as skipping
+recommend or Selection; `watch()` on a `.run()` / sync execution; `inputs.sync`
+on protein-prep (not in the tool schema)
+
+**Loops-off prepare**:
+Protein Prep `action=prepare` with `model_missing_loops=false`: apply the
+frozen Selection (keep/skip chains, waters, ligands, cofactors), skip loop
+modelling, still protonate. Quoted `method: direct`; `pdb_id` optional.
+_Avoid_: skipping Protein Prep; skipping protonation; constructing
+`ProteinPrep(protein, model_missing_loops=False)` (illegal on recommend)
 
 **Prepared protein (CLI)**:
 In-memory :class:`~deeporigin.drug_discovery.structures.protein.Protein` returned

--- a/docs/dd/how-to/proteins.md
+++ b/docs/dd/how-to/proteins.md
@@ -211,18 +211,20 @@ pockets[0].show()
 ### Preparing a protein
 
 Inventory components, then clean the structure (optional loop modelling,
-protonation) with [ProteinPrep](../tools/proteinprep.md). Recommend with
-`start()`. To skip loop modelling, call `as_prepare(model_missing_loops=False)`
-then `run()`, which blocks until the prepared protein is ready.
+protonation) with [ProteinPrep](../tools/proteinprep.md). `recommend()` updates
+the same object with an editable Selection. Resolve any review decisions, then
+disable loop modelling and call `run()`, which blocks until the prepared
+protein is ready.
 
 ```{.python notest}
 from deeporigin.drug_discovery import Protein, ProteinPrep
 
 protein = Protein.from_pdb_id("1EBY")
-rec = ProteinPrep(protein)
-rec.start()
-rec.wait()
-prepared = rec.as_prepare(model_missing_loops=False).run()
+prep = ProteinPrep(protein=protein)
+prep.recommend()
+prep.skip(["ligand:LIG:A:100"])  # Resolve IDs marked for review.
+prep.model_missing_loops = False
+prepared = prep.run()
 ```
 
 ### Visualizing a protein

--- a/docs/dd/how-to/proteins.md
+++ b/docs/dd/how-to/proteins.md
@@ -212,9 +212,9 @@ pockets[0].show()
 
 Inventory components, then clean the structure (optional loop modelling,
 protonation) with [ProteinPrep](../tools/proteinprep.md). `recommend()` updates
-the same object with an editable Selection. Resolve any review decisions, then
-disable loop modelling and call `run()`, which blocks until the prepared
-protein is ready.
+the same object with an editable Selection and returns a component table.
+Resolve any review decisions, then disable loop modelling and call `run()`,
+which blocks until the prepared protein is ready.
 
 ```{.python notest}
 from deeporigin.drug_discovery import Protein, ProteinPrep
@@ -222,7 +222,8 @@ from deeporigin.drug_discovery import Protein, ProteinPrep
 protein = Protein.from_pdb_id("1EBY")
 prep = ProteinPrep(protein=protein)
 prep.recommend()
-prep.skip(["ligand:LIG:A:100"])  # Resolve IDs marked for review.
+prep.recommendation(decision="review")
+prep.skip(decision="review")
 prep.model_missing_loops = False
 prepared = prep.run()
 ```

--- a/docs/dd/how-to/proteins.md
+++ b/docs/dd/how-to/proteins.md
@@ -210,18 +210,19 @@ pockets[0].show()
 
 ### Preparing a protein
 
-Clean a structure (keep/remove lists, loop modelling, protonation) with
-[ProteinPrep](../tools/proteinprep.md). Protein Prep is async-only: `start()`,
-then `wait()` or `watch()`, then `get_results()`.
+Inventory components, then clean the structure (optional loop modelling,
+protonation) with [ProteinPrep](../tools/proteinprep.md). Recommend with
+`start()`. To skip loop modelling, call `as_prepare(model_missing_loops=False)`
+then `run()`, which blocks until the prepared protein is ready.
 
 ```{.python notest}
 from deeporigin.drug_discovery import Protein, ProteinPrep
 
 protein = Protein.from_pdb_id("1EBY")
-prep = ProteinPrep(protein)
-prep.start()
-prep.wait()
-prepared = prep.get_results()
+rec = ProteinPrep(protein)
+rec.start()
+rec.wait()
+prepared = rec.as_prepare(model_missing_loops=False).run()
 ```
 
 ### Visualizing a protein

--- a/docs/dd/ref/protein_prep.md
+++ b/docs/dd/ref/protein_prep.md
@@ -1,10 +1,10 @@
 # `deeporigin.drug_discovery.protein_prep`
 
 `ProteinPrep` drives platform tool `deeporigin.protein-prep`. Recommend
-inventories components; prepare applies a frozen Selection then cleans the
-structure. ``start()`` is always valid. ``run()`` is only for prepare with
-``model_missing_loops=False``: it blocks and returns an in-memory ``Protein``.
-There is no quote.
+inventories components and updates the same object with an editable Selection.
+Prepare applies resolved keep/skip decisions and cleans the structure.
+``run()`` is loops-off and blocking; ``start()`` submits asynchronous prepare
+with loop modelling either off or on. There is no quote.
 
 ::: src.drug_discovery.protein_prep
     options:

--- a/docs/dd/ref/protein_prep.md
+++ b/docs/dd/ref/protein_prep.md
@@ -1,8 +1,9 @@
 # `deeporigin.drug_discovery.protein_prep`
 
 `ProteinPrep` drives platform tool `deeporigin.protein-prep`. Recommend
-inventories components and updates the same object with an editable Selection.
-Prepare applies resolved keep/skip decisions and cleans the structure.
+inventories components, returns a `RecommendationView` table, and updates the
+same object with an editable Selection. Prepare applies resolved keep/skip
+decisions and cleans the structure.
 ``run()`` is loops-off and blocking; ``start()`` submits asynchronous prepare
 with loop modelling either off or on. There is no quote.
 

--- a/docs/dd/ref/protein_prep.md
+++ b/docs/dd/ref/protein_prep.md
@@ -1,9 +1,10 @@
 # `deeporigin.drug_discovery.protein_prep`
 
-`ProteinPrep` drives platform tool `deeporigin.protein-prep` to clean a protein
-structure. The workflow is async-only: ``start()``, then ``wait()`` /
-``watch()``, then ``get_results()`` (an in-memory ``Protein``). There is no
-``run()`` and no quote.
+`ProteinPrep` drives platform tool `deeporigin.protein-prep`. Recommend
+inventories components; prepare applies a frozen Selection then cleans the
+structure. ``start()`` is always valid. ``run()`` is only for prepare with
+``model_missing_loops=False``: it blocks and returns an in-memory ``Protein``.
+There is no quote.
 
 ::: src.drug_discovery.protein_prep
     options:

--- a/docs/dd/tools/overview.md
+++ b/docs/dd/tools/overview.md
@@ -82,7 +82,7 @@ The commonly available methods are:
 
 Not every method is available on every tool. The tool-specific pages document
 the supported execution modes, inputs, outputs, and examples.
-[`ProteinPrep`](proteinprep.md) recommends with `start()`, then prepares. Skip
-loop modelling (`model_missing_loops=False`) and call `run()` to block until
-the prepared protein is ready; loop modelling uses `start()` again. This tool
+[`ProteinPrep`](proteinprep.md) inventories with `recommend()`, then prepares.
+Skip loop modelling (`model_missing_loops=False`) and call `run()` to block until
+the prepared protein is ready; loop modelling uses `start()`. This tool
 does not produce a cost quote.

--- a/docs/dd/tools/overview.md
+++ b/docs/dd/tools/overview.md
@@ -82,5 +82,7 @@ The commonly available methods are:
 
 Not every method is available on every tool. The tool-specific pages document
 the supported execution modes, inputs, outputs, and examples.
-[`ProteinPrep`](proteinprep.md) is async-only (`start()`, not `run()`) and does
-not produce a cost quote.
+[`ProteinPrep`](proteinprep.md) recommends with `start()`, then prepares. Skip
+loop modelling (`model_missing_loops=False`) and call `run()` to block until
+the prepared protein is ready; loop modelling uses `start()` again. This tool
+does not produce a cost quote.

--- a/docs/dd/tools/proteinprep.md
+++ b/docs/dd/tools/proteinprep.md
@@ -1,59 +1,107 @@
 # ProteinPrep
 
-Prepare a [`Protein`](../ref/protein.md) for virtual screening or target work
-with the Deep Origin Protein Prep tool. Protein Prep cleans the structure using
-the chain, cofactor, water, and ligand lists you pass in, then runs loop
-modelling and protonation.
+Inventory and prepare a [`Protein`](../ref/protein.md) with the Deep Origin
+Protein Prep tool. The tool is two steps on one key:
 
-`ProteinPrep` is **async only**: submit with `start()`, track with `wait()` or
-`watch()`, then load the prepared structure with `get_results()`. There is no
-`run()`, and this tool does not produce a cost quote.
+1. **Recommend** inventories chains, ligands, cofactors, and waters.
+2. **Prepare** applies a frozen keep/skip map (a Selection), then protonates
+   and optionally runs loop modelling.
 
-`get_results()` returns an in-memory [`Protein`](../ref/protein.md) whose
-`remote_path` points at the prepared PDB. That object has no platform protein
-id until you `sync()` or `update()` it. The input protein on the `ProteinPrep`
-instance is unchanged.
+`start()` is always valid. Track those jobs with `wait()` or `watch()`, then
+load results. `run()` is only valid when you skip loop modelling
+(`model_missing_loops=False`): it blocks until the prepare job finishes and
+returns the prepared protein. This tool does not produce a cost quote.
 
-## Preparing a protein
+`get_results()` (after a prepare run) returns an in-memory
+[`Protein`](../ref/protein.md) whose `remote_path` points at the prepared PDB.
+That object has no platform protein id until you `sync()` or `update()` it. The
+input protein on the `ProteinPrep` instance is unchanged.
 
-Create a protein, then a `ProteinPrep`. The tool needs a 4-character
-[Protein Data Bank (PDB) :octicons-link-external-16:](https://www.rcsb.org/)
-ID for loop-modelling templates. If the protein already has `pdb_id` (for
-example from `Protein.from_pdb_id`), you can omit it.
+## Recommending components
+
+Create a protein, then a `ProteinPrep` with no selection. `start()` submits
+`action=recommend`. After the job finishes, `get_recommendation()` returns the
+component inventory.
 
 ```{.python notest}
 from deeporigin.drug_discovery import Protein, ProteinPrep, BRD_DATA_DIR
 
 protein = Protein.from_file(BRD_DATA_DIR / "brd.pdb")
-prep = ProteinPrep(protein, pdb_id="1EBY")
-prep.start()
-prep.wait()
-prepared = prep.get_results()
+rec = ProteinPrep(protein, pdb_id="1EBY")
+rec.start()
+rec.wait()
+recommendation = rec.get_recommendation()
 ```
+
+`pdb_id` is optional on recommend. If the protein already has `pdb_id` (for
+example from `Protein.from_pdb_id`), or you pass it here, `as_prepare()` reuses
+it for loop-modelling templates.
 
 In a notebook, watch progress while the execution runs:
 
 ```{.python notest}
-prep = ProteinPrep(protein, pdb_id="1EBY")
+rec = ProteinPrep(protein, pdb_id="1EBY")
+rec.start()
+task = await rec.watch()
+rec.wait()
+recommendation = rec.get_recommendation()
+```
+
+## Preparing a protein
+
+Turn the recommendation into a frozen Selection (every `review` becomes `skip`
+by default). Skip loop modelling and block until the prepared protein is
+ready:
+
+```{.python notest}
+prep = rec.as_prepare(model_missing_loops=False)
+prepared = prep.run()
+```
+
+Loop modelling stays on by default. That path is longer, so submit with
+`start()` instead of `run()`:
+
+```{.python notest}
+prep = rec.as_prepare()
 prep.start()
-task = await prep.watch()
 prep.wait()
 prepared = prep.get_results()
 ```
 
-Optional keep and remove lists match the tool inputs. Empty keep-chain means
-keep all chains; empty cofactor and water lists keep none of those; empty
-remove-ligand means no extra ligand names are stripped.
+Or build the prepare run yourself from the recommendation dict:
 
 ```{.python notest}
+prep = ProteinPrep.from_recommendation(protein, recommendation, pdb_id="1EBY")
+```
+
+The tool needs a 4-character
+[Protein Data Bank (PDB) :octicons-link-external-16:](https://www.rcsb.org/)
+ID for loop-modelling templates unless you skip loop modelling with
+`model_missing_loops=False`.
+
+You can edit the Selection before prepare. `selection_from_recommendation`
+maps each component to `keep` or `skip`; pass `resolve_review_as="keep"` to
+keep items the analyzer marked for review:
+
+```{.python notest}
+selection = ProteinPrep.selection_from_recommendation(
+    recommendation,
+    resolve_review_as="skip",
+)
+selection["decisions"]["chain:A"] = "keep"
 prep = ProteinPrep(
     protein,
-    pdb_id="1EBY",
-    keep_chain_ids=["A"],
-    keep_cofactor_ids=["MG", "ZN"],
-    keep_water_residue_names=["HOH"],
-    remove_ligand_ids=["LIG"],
+    selection=selection,
+    model_missing_loops=False,
 )
+prepared = prep.run()
+```
+
+Displaying the object in a notebook or REPL lists every parameter you can
+set and its current value (`action`, `pdb_id`, `selection`, and so on):
+
+```{.python notest}
+prep
 ```
 
 ## Working with existing runs
@@ -68,5 +116,8 @@ prep = ProteinPrep.from_id("<executionId>")
 prep = ProteinPrep.from_last_run()
 
 prep.sync()
-prepared = prep.get_results()
+if prep.action == "recommend":
+    recommendation = prep.get_recommendation()
+else:
+    prepared = prep.get_results()
 ```

--- a/docs/dd/tools/proteinprep.md
+++ b/docs/dd/tools/proteinprep.md
@@ -1,123 +1,126 @@
 # ProteinPrep
 
-Inventory and prepare a [`Protein`](../ref/protein.md) with the Deep Origin
-Protein Prep tool. The tool is two steps on one key:
+Inventory and prepare a [`Protein`](../ref/protein.md) with one configurable
+`ProteinPrep` object. Recommendation identifies chains, ligands, cofactors, and
+waters. Preparation applies your keep/skip decisions, protonates the structure,
+and optionally models missing loops.
 
-1. **Recommend** inventories chains, ligands, cofactors, and waters.
-2. **Prepare** applies a frozen keep/skip map (a Selection), then protonates
-   and optionally runs loop modelling.
+## Recommend and review
 
-`start()` is always valid. Track those jobs with `wait()` or `watch()`, then
-load results. `run()` is only valid when you skip loop modelling
-(`model_missing_loops=False`): it blocks until the prepare job finishes and
-returns the prepared protein. This tool does not produce a cost quote.
-
-`get_results()` (after a prepare run) returns an in-memory
-[`Protein`](../ref/protein.md) whose `remote_path` points at the prepared PDB.
-That object has no platform protein id until you `sync()` or `update()` it. The
-input protein on the `ProteinPrep` instance is unchanged.
-
-## Recommending components
-
-Create a protein, then a `ProteinPrep` with no selection. `start()` submits
-`action=recommend`. After the job finishes, `get_recommendation()` returns the
-component inventory.
+Create the object and request recommended settings. `recommend()` blocks,
+returns `None`, and updates both `recommendation` and `selection`. It does not
+bind the object to the temporary recommendation execution.
 
 ```{.python notest}
-from deeporigin.drug_discovery import Protein, ProteinPrep, BRD_DATA_DIR
+from deeporigin.drug_discovery import BRD_DATA_DIR, Protein, ProteinPrep
 
 protein = Protein.from_file(BRD_DATA_DIR / "brd.pdb")
-rec = ProteinPrep(protein, pdb_id="1EBY")
-rec.start()
-rec.wait()
-recommendation = rec.get_recommendation()
+prep = ProteinPrep(protein=protein)
+prep.recommend()
 ```
 
-`pdb_id` is optional on recommend. If the protein already has `pdb_id` (for
-example from `Protein.from_pdb_id`), or you pass it here, `as_prepare()` reuses
-it for loop-modelling templates.
+`prep.recommendation` contains the complete analyzer evidence.
+`prep.selection` contains the editable decisions. Both properties return
+defensive copies.
 
-In a notebook, watch progress while the execution runs:
+Recommendations may mark ambiguous components as `review`. Resolve them before
+preparation with the component IDs from `prep.recommendation`:
 
 ```{.python notest}
-rec = ProteinPrep(protein, pdb_id="1EBY")
-rec.start()
-task = await rec.watch()
-rec.wait()
-recommendation = rec.get_recommendation()
+prep.keep(["chain:A", "cofactor:HEM:A:200"])
+prep.skip(["ligand:LIG:A:100"])
 ```
 
-## Preparing a protein
+`keep()` and `skip()` change only the IDs you name. They reject unknown IDs.
+Preparation reports any unresolved `review` IDs instead of silently skipping
+them.
 
-Turn the recommendation into a frozen Selection (every `review` becomes `skip`
-by default). Skip loop modelling and block until the prepared protein is
-ready:
+You may call `recommend()` again before preparation. A successful refresh
+replaces the recommendation and Selection. If refresh fails, the previous
+successful settings remain intact.
+
+## Prepare without loop modelling
+
+Disable loop modelling to use blocking preparation:
 
 ```{.python notest}
-prep = rec.as_prepare(model_missing_loops=False)
+prep.model_missing_loops = False
 prepared = prep.run()
 ```
 
-Loop modelling stays on by default. That path is longer, so submit with
-`start()` instead of `run()`:
+`run()` returns an in-memory [`Protein`](../ref/protein.md) whose
+`remote_path` points to the prepared Protein Data Bank (PDB) file. It has no
+platform protein ID until you call `sync()` or `update()`. The original input
+protein is unchanged.
+
+Loops-off preparation may also run asynchronously:
 
 ```{.python notest}
-prep = rec.as_prepare()
 prep.start()
 prep.wait()
 prepared = prep.get_results()
 ```
 
-Or build the prepare run yourself from the recommendation dict:
+## Prepare with loop modelling
+
+Loop modelling is enabled by default and may take longer, so use `start()`:
 
 ```{.python notest}
-prep = ProteinPrep.from_recommendation(protein, recommendation, pdb_id="1EBY")
+prep.pdb_id = "1EBY"
+prep.model_missing_loops = True
+prep.start()
+prep.wait()
+prepared = prep.get_results()
 ```
 
-The tool needs a 4-character
+Loop modelling requires a four-character
 [Protein Data Bank (PDB) :octicons-link-external-16:](https://www.rcsb.org/)
-ID for loop-modelling templates unless you skip loop modelling with
-`model_missing_loops=False`.
+ID. `ProteinPrep` initially uses `protein.pdb_id` when available; otherwise set
+`prep.pdb_id` before submission.
 
-You can edit the Selection before prepare. `selection_from_recommendation`
-maps each component to `keep` or `skip`; pass `resolve_review_as="keep"` to
-keep items the analyzer marked for review:
+## Use a saved Selection
+
+Advanced callers can skip recommendation by passing or assigning a saved
+Selection:
 
 ```{.python notest}
-selection = ProteinPrep.selection_from_recommendation(
-    recommendation,
-    resolve_review_as="skip",
-)
-selection["decisions"]["chain:A"] = "keep"
 prep = ProteinPrep(
-    protein,
-    selection=selection,
+    protein=protein,
+    selection=saved_selection,
     model_missing_loops=False,
 )
 prepared = prep.run()
 ```
 
-Displaying the object in a notebook or REPL lists every parameter you can
-set and its current value (`action`, `pdb_id`, `selection`, and so on):
+A Selection contains `source_sha256`, `analyzer_version`, and a `decisions`
+mapping. Assignment copies and validates it. Local decisions may contain
+`review`, but all reviews must become `keep` or `skip` before preparation.
+
+## Object lifecycle
+
+`protein` is constructor-only. Before preparation, you may change `pdb_id`,
+`selection`, and `model_missing_loops`.
+
+`run()` or `start()` binds the object to the durable preparation execution and
+sets `prep.id`. From that point onward, configuration is permanently frozen.
+Displaying the object shows its configuration, a Selection summary,
+recommendation availability, and—after submission—execution status and
+progress.
+
+This tool does not produce a cost quote, so Protein Prep methods have no
+`quote` or `approve_amount` arguments.
+
+## Reconnect to an execution
+
+Reconnect to a durable preparation or historical recommendation execution:
 
 ```{.python notest}
-prep
-```
-
-## Working with existing runs
-
-Reconnect to a Protein Prep run started earlier, in this or a previous session:
-
-```{.python notest}
-from deeporigin.drug_discovery import ProteinPrep
-
 prep = ProteinPrep.from_id("<executionId>")
-# Or the most recently created ProteinPrep run:
+# Or:
 prep = ProteinPrep.from_last_run()
-
-prep.sync()
-if prep.action == "recommend":
-    recommendation = prep.get_recommendation()
-else:
-    prepared = prep.get_results()
 ```
+
+For preparation executions, call `sync()` and `get_results()`. Historical
+recommendation executions expose their evidence through `prep.recommendation`.
+The internal platform operation is deliberately not exposed as user-settable
+`action`.

--- a/docs/dd/tools/proteinprep.md
+++ b/docs/dd/tools/proteinprep.md
@@ -8,8 +8,8 @@ and optionally models missing loops.
 ## Recommend and review
 
 Create the object and request recommended settings. `recommend()` blocks,
-returns `None`, and updates both `recommendation` and `selection`. It does not
-bind the object to the temporary recommendation execution.
+returns a component table, and updates both `recommendation` and `selection`.
+It does not bind the object to the temporary recommendation execution.
 
 ```{.python notest}
 from deeporigin.drug_discovery import BRD_DATA_DIR, Protein, ProteinPrep
@@ -19,19 +19,29 @@ prep = ProteinPrep(protein=protein)
 prep.recommend()
 ```
 
-`prep.recommendation` contains the complete analyzer evidence.
-`prep.selection` contains the editable decisions. Both properties return
-defensive copies.
-
-Recommendations may mark ambiguous components as `review`. Resolve them before
-preparation with the component IDs from `prep.recommendation`:
+`prep.recommendation` is a table of inventoried components. Columns include
+the analyzer's frozen `recommendation` tag and your live `decision`. Filter
+with keyword arguments; the call returns a
+[pandas :octicons-link-external-16:](https://pandas.pydata.org/) DataFrame:
 
 ```{.python notest}
-prep.keep(["chain:A", "cofactor:HEM:A:200"])
-prep.skip(["ligand:LIG:A:100"])
+prep.recommendation(decision="review")
 ```
 
-`keep()` and `skip()` change only the IDs you name. They reject unknown IDs.
+The analyzer payload is `prep.recommendation.raw`. `prep.selection` is the
+editable decision map and returns a defensive copy.
+
+Resolve every `review` decision before preparation. `keep()` and `skip()`
+accept component IDs, a filtered DataFrame, or keyword matchers (`kind`,
+`subtype`, `decision`). Matchers are equivalent to passing the matching IDs:
+
+```{.python notest}
+prep.keep(kind="water")
+prep.skip(decision="review")
+prep.keep(["chain:A", "cofactor:HEM:A:200"])
+```
+
+Do not mix IDs with keyword matchers in one call. Unknown IDs are rejected.
 Preparation reports any unresolved `review` IDs instead of silently skipping
 them.
 
@@ -104,8 +114,8 @@ mapping. Assignment copies and validates it. Local decisions may contain
 `run()` or `start()` binds the object to the durable preparation execution and
 sets `prep.id`. From that point onward, configuration is permanently frozen.
 Displaying the object shows its configuration, a Selection summary,
-recommendation availability, and—after submission—execution status and
-progress.
+recommendation component count, and—after submission—execution status and
+progress. Display `prep.recommendation` to see the component table.
 
 This tool does not produce a cost quote, so Protein Prep methods have no
 `quote` or `approve_amount` arguments.
@@ -121,6 +131,7 @@ prep = ProteinPrep.from_last_run()
 ```
 
 For preparation executions, call `sync()` and `get_results()`. Historical
-recommendation executions expose their evidence through `prep.recommendation`.
+recommendation executions expose their component table through
+`prep.recommendation`.
 The internal platform operation is deliberately not exposed as user-settable
 `action`.

--- a/docs/dev/mock-server.md
+++ b/docs/dev/mock-server.md
@@ -112,7 +112,7 @@ This is the most complex part of the mock server. When client code runs a tool (
 
 `run_tool` inspects the request body and the URL's `tool_key` and produces a tool execution DTO with `executionId`, `status`, `userInputs`, `jobOutputs`, `quotationResult`, `tool: {key, version}`, and `type: "ToolExecution"`. Several tool keys are special-cased:
 
-- `deeporigin.docking` (single ligand, `sync=True`), `deeporigin.pocket-finder`, `deeporigin.system-prep`, `deeporigin.protein-prep` complete in one POST via `_create_blocking_run_dto` and inject their fixture-backed `jobOutputs` into the result-explorer pool.
+- `deeporigin.docking` (single ligand, `sync=True`), `deeporigin.pocket-finder`, `deeporigin.system-prep`, `deeporigin.protein-prep` complete in one POST via `_create_blocking_run_dto` and inject their fixture-backed `jobOutputs` into the result-explorer pool. Protein Prep v2 branches on `inputs.action`: `recommend` loads `tool-runs/deeporigin.protein-prep/recommend.json`; `prepare` (or omitted action) loads `run.json`.
 - `deeporigin.mol-props-protonation` returns deterministic `protonation_states` from the request inputs (`_build_protonation_execution`).
 - `deeporigin.mol-props-*` (logd, logp, ames, …) hash the normalized request body and look up the recorded outputs at `tests/fixtures/tool-runs/{tool_key}/{body_hash}.json` (`_build_molprops_execution`). The fixture's per-ligand `jobOutputs` rows are re-keyed by the request's ligand IDs.
 - `deeporigin.mol-props-combined` (`Molprops`) synthesizes per-ligand rows and a matching `quotationResult` (`_build_combined_molprops_execution`). When the request body includes `approveAmount: 0` (quote-only), the mock clears `jobOutputs` and sets `status` to `Quoted`.

--- a/docs/notebooks/clean/protein-prep.ipynb
+++ b/docs/notebooks/clean/protein-prep.ipynb
@@ -2,23 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "676d8048",
+   "id": "3fe949f5",
    "metadata": {},
    "source": [
     "# Protein Prep\n",
     "\n",
-    "Inventory a protein (`action=recommend`), then prepare it (`action=prepare`)\n",
-    "with the Deep Origin Protein Prep tool.\n",
-    "\n",
-    "`start()` is always valid. `run()` is only for prepare with\n",
-    "`model_missing_loops=False` (skip loop modelling): it blocks and returns\n",
-    "the prepared protein.\n"
+    "Recommend settings and prepare a protein with one `ProteinPrep` object.\n",
+    "`recommend()` updates the object without binding an execution ID. `run()` is\n",
+    "blocking and requires `model_missing_loops=False`; `start()` submits\n",
+    "asynchronous preparation with loop modelling either off or on."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4f335f2",
+   "id": "a4551299",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,64 +27,162 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0f0bb59",
+   "id": "f7dd3ec0",
    "metadata": {},
    "outputs": [],
    "source": [
     "from deeporigin.drug_discovery import BRD_DATA_DIR, Protein, ProteinPrep\n",
     "from deeporigin.platform import DeepOriginClient\n",
     "\n",
-    "client = DeepOriginClient()\n",
+    "client = DeepOriginClient.from_disk()\n",
     "protein = Protein.from_file(BRD_DATA_DIR / \"brd.pdb\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "636d8720",
+   "id": "2baefea4",
    "metadata": {},
    "source": [
-    "## Recommend\n",
+    "## Recommend and review\n",
     "\n",
-    "`ProteinPrep(protein)` with no selection submits `action=recommend`.\n"
+    "`recommend()` blocks, returns `None`, and populates `recommendation` plus an\n",
+    "editable `selection`. Resolve every component marked `review` before prepare."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc501a22",
+   "id": "5e99c3c3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "rec = ProteinPrep(protein, pdb_id=\"1EBY\", client=client)\n",
-    "rec.start()\n",
-    "rec.wait()\n",
-    "recommendation = rec.get_recommendation()\n",
-    "recommendation[\"components\"][:3]"
+    "prep = ProteinPrep(protein=protein, pdb_id=\"1EBY\", client=client)\n",
+    "prep.recommend()\n",
+    "prep.recommendation[\"components\"][:3]"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdfcb7fb",
+   "metadata": {},
+   "source": [
+    "Resolve the ambiguous ligand explicitly, then skip loop modelling. `run()`\n",
+    "blocks until the prepared protein is ready and permanently binds `prep` to the\n",
+    "preparation execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6249c6ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prep.skip([\"ligand:LIG:A:100\"])\n",
+    "prep.model_missing_loops = False\n",
+    "prepared = prep.run()\n",
+    "prepared"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "986f5f2d",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4534bd75",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fecbee0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e654d198",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fd869e8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbd261a2",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3dfef79",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "664dbf69",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb49fb13",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "270125f2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f420d434",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a58ab1e4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
    "id": "e5c534d7",
    "metadata": {},
-   "source": [
-    "## Prepare (skip loop modelling)\n",
-    "\n",
-    "`as_prepare(model_missing_loops=False)` turns the recommendation into a frozen\n",
-    "Selection (reviews become `skip`) and skips loop modelling. `run()` blocks\n",
-    "until the prepared protein is ready.\n"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c54741db",
+   "id": "cb62d905",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "prep = rec.as_prepare(model_missing_loops=False)\n",
-    "prepared = prep.run()\n",
-    "prepared"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/clean/protein-prep.ipynb
+++ b/docs/notebooks/clean/protein-prep.ipynb
@@ -8,9 +8,9 @@
     "# Protein Prep\n",
     "\n",
     "Recommend settings and prepare a protein with one `ProteinPrep` object.\n",
-    "`recommend()` updates the object without binding an execution ID. `run()` is\n",
-    "blocking and requires `model_missing_loops=False`; `start()` submits\n",
-    "asynchronous preparation with loop modelling either off or on."
+    "`recommend()` returns a component table and does not bind an execution ID.\n",
+    "`run()` is blocking and requires `model_missing_loops=False`; `start()`\n",
+    "submits asynchronous preparation with loop modelling either off or on."
    ]
   },
   {
@@ -45,8 +45,9 @@
    "source": [
     "## Recommend and review\n",
     "\n",
-    "`recommend()` blocks, returns `None`, and populates `recommendation` plus an\n",
-    "editable `selection`. Resolve every component marked `review` before prepare."
+    "`recommend()` blocks and returns a table of components. Filter unresolved\n",
+    "decisions with `recommendation(decision=\"review\")`. Resolve every `review`\n",
+    "before prepare."
    ]
   },
   {
@@ -57,8 +58,17 @@
    "outputs": [],
    "source": [
     "prep = ProteinPrep(protein=protein, pdb_id=\"1EBY\", client=client)\n",
-    "prep.recommend()\n",
-    "prep.recommendation[\"components\"][:3]"
+    "prep.recommend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "rec-filter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prep.recommendation(decision=\"review\")"
    ]
   },
   {
@@ -66,7 +76,7 @@
    "id": "cdfcb7fb",
    "metadata": {},
    "source": [
-    "Resolve the ambiguous ligand explicitly, then skip loop modelling. `run()`\n",
+    "Keep waters and skip remaining reviews, then skip loop modelling. `run()`\n",
     "blocks until the prepared protein is ready and permanently binds `prep` to the\n",
     "preparation execution."
    ]
@@ -78,111 +88,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prep.skip([\"ligand:LIG:A:100\"])\n",
+    "prep.keep(kind=\"water\").skip(decision=\"review\")\n",
     "prep.model_missing_loops = False\n",
     "prepared = prep.run()\n",
     "prepared"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "986f5f2d",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4534bd75",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5fecbee0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e654d198",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4fd869e8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fbd261a2",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f3dfef79",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "664dbf69",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cb49fb13",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "270125f2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f420d434",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a58ab1e4",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e5c534d7",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cb62d905",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/clean/protein-prep.ipynb
+++ b/docs/notebooks/clean/protein-prep.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b74a5744",
+   "metadata": {},
+   "source": [
+    "# Protein Prep\n",
+    "\n",
+    "Inventory a protein (`action=recommend`), then prepare it (`action=prepare`)\n",
+    "with the Deep Origin Protein Prep tool.\n",
+    "\n",
+    "`ProteinPrep` is async-only: `start()`, `wait()` / `watch()`, then\n",
+    "`get_recommendation()` or `get_results()`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ae294b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13834c3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from deeporigin.drug_discovery import BRD_DATA_DIR, Protein, ProteinPrep\n",
+    "from deeporigin.platform import DeepOriginClient\n",
+    "\n",
+    "client = DeepOriginClient()\n",
+    "protein = Protein.from_file(BRD_DATA_DIR / \"brd.pdb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b571847",
+   "metadata": {},
+   "source": [
+    "## Recommend\n",
+    "\n",
+    "`ProteinPrep(protein)` with no selection submits `action=recommend`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99017aab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rec = ProteinPrep(protein, pdb_id=\"1EBY\", client=client)\n",
+    "rec.start()\n",
+    "rec.wait()\n",
+    "recommendation = rec.get_recommendation()\n",
+    "recommendation[\"components\"][:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35772e17",
+   "metadata": {},
+   "source": [
+    "## Prepare\n",
+    "\n",
+    "`as_prepare()` turns the recommendation into a frozen Selection (reviews become\n",
+    "`skip`) and builds a prepare run. Loop modelling uses `pdb_id`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01654970",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prep = rec.as_prepare()\n",
+    "prep.start()\n",
+    "prep.wait()\n",
+    "prepared = prep.get_results()\n",
+    "prepared"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/clean/protein-prep.ipynb
+++ b/docs/notebooks/clean/protein-prep.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b74a5744",
+   "id": "676d8048",
    "metadata": {},
    "source": [
     "# Protein Prep\n",
@@ -10,14 +10,15 @@
     "Inventory a protein (`action=recommend`), then prepare it (`action=prepare`)\n",
     "with the Deep Origin Protein Prep tool.\n",
     "\n",
-    "`ProteinPrep` is async-only: `start()`, `wait()` / `watch()`, then\n",
-    "`get_recommendation()` or `get_results()`.\n"
+    "`start()` is always valid. `run()` is only for prepare with\n",
+    "`model_missing_loops=False` (skip loop modelling): it blocks and returns\n",
+    "the prepared protein.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ae294b3",
+   "id": "a4f335f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13834c3a",
+   "id": "d0f0bb59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +42,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b571847",
+   "id": "636d8720",
    "metadata": {},
    "source": [
     "## Recommend\n",
@@ -52,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99017aab",
+   "id": "fc501a22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,26 +66,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35772e17",
+   "id": "e5c534d7",
    "metadata": {},
    "source": [
-    "## Prepare\n",
+    "## Prepare (skip loop modelling)\n",
     "\n",
-    "`as_prepare()` turns the recommendation into a frozen Selection (reviews become\n",
-    "`skip`) and builds a prepare run. Loop modelling uses `pdb_id`.\n"
+    "`as_prepare(model_missing_loops=False)` turns the recommendation into a frozen\n",
+    "Selection (reviews become `skip`) and skips loop modelling. `run()` blocks\n",
+    "until the prepared protein is ready.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01654970",
+   "id": "c54741db",
    "metadata": {},
    "outputs": [],
    "source": [
-    "prep = rec.as_prepare()\n",
-    "prep.start()\n",
-    "prep.wait()\n",
-    "prepared = prep.get_results()\n",
+    "prep = rec.as_prepare(model_missing_loops=False)\n",
+    "prepared = prep.run()\n",
     "prepared"
    ]
   }

--- a/src/drug_discovery/__init__.py
+++ b/src/drug_discovery/__init__.py
@@ -35,6 +35,7 @@ __all__ = [
     "Patent",
     "Enumerator",
     "ProteinPrep",
+    "RecommendationView",
 ]
 
 DATA_DIR = files("deeporigin.data")
@@ -70,6 +71,10 @@ _LAZY_IMPORTS = {
     "Patent": ("deeporigin.drug_discovery.patent", "Patent"),
     "Enumerator": ("deeporigin.drug_discovery.enumerator", "Enumerator"),
     "ProteinPrep": ("deeporigin.drug_discovery.protein_prep", "ProteinPrep"),
+    "RecommendationView": (
+        "deeporigin.drug_discovery.protein_prep",
+        "RecommendationView",
+    ),
     "Execution": ("deeporigin.drug_discovery.execution", "Execution"),
     "PlatformStatus": ("deeporigin.platform.constants", "PlatformStatus"),
 }

--- a/src/drug_discovery/class-design.md
+++ b/src/drug_discovery/class-design.md
@@ -11,7 +11,7 @@ This concerns the tool/execution wrapper classes:
 - ConstrainedDocking
 - SystemPrep
 - PocketFinder
-- ProteinPrep (async-only: ``start()``, no ``run()``)
+- ProteinPrep (``start()`` always; ``run()`` only for loops-off prepare)
 
 etc
 

--- a/src/drug_discovery/execution.py
+++ b/src/drug_discovery/execution.py
@@ -180,6 +180,23 @@ class Execution:
         This property cannot be set manually."""
         return self._cost
 
+    def _require_no_execution_id(self, attr: str) -> None:
+        """Raise if this instance already has a platform execution id.
+
+        Used by input setters so callers can mutate configuration only before
+        ``start()``, ``run()``, or a quote.
+
+        Args:
+            attr: Public attribute the caller tried to assign.
+
+        Raises:
+            AttributeError: If :attr:`id` is set.
+        """
+        if getattr(self, "_id", None) is not None:
+            raise AttributeError(
+                f"cannot assign to {attr!r}: execution id is already set"
+            )
+
     @property
     def name(self) -> str | None:
         """Optional user-defined label for this execution.
@@ -191,8 +208,7 @@ class Execution:
     @name.setter
     def name(self, value: str | None) -> None:
         """Set ``name`` only before the platform assigns an execution ``id``."""
-        if getattr(self, "_id", None) is not None:
-            raise AttributeError("cannot assign to 'name': execution id is already set")
+        self._require_no_execution_id("name")
         self._name = value
 
     def _make_payload(

--- a/src/drug_discovery/protein_prep.py
+++ b/src/drug_discovery/protein_prep.py
@@ -10,21 +10,22 @@ Usage::
 
     prep = ProteinPrep(protein)
     prep.recommend()
-    prep.keep(["chain:A"])
-    prep.skip(["ligand:LIG:A:100"])
+    prep.keep(kind="water")
+    prep.skip(decision="review")
     prep.model_missing_loops = False
     prepared = prep.run()
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from html import escape
 import re
 from typing import Any, Literal, NamedTuple, Self
 
 from beartype import beartype
+import pandas as pd
 
 from deeporigin.drug_discovery.execution import Execution
 from deeporigin.drug_discovery.execution_mixins import (
@@ -37,13 +38,20 @@ from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.client import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS
 from deeporigin.utils.constants import (
+    PROTEIN_PREP_COMPONENT_KINDS,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_DATAFRAME_ID_COLUMN_MSG,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_DISPLAY_NONE,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_KEEP_SKIP_EMPTY_MSG,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_KEEP_SKIP_MIXED_MSG,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_KEEP_SKIP_VIEW_MSG,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_NO_OUTPUT_PATHS_MSG,
     PROTEIN_PREP_NO_RECOMMENDATION_MSG,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_PDB_ID_PATTERN,
     PROTEIN_PREP_PDB_ID_REQUIRED_MSG,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_RECOMMENDATION_COLUMNS,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_SUBTYPE_REQUIRES_RECOMMENDATION_MSG,  # ty:ignore[unresolved-import]
 )
 
 _PDB_ID_RE = re.compile(PROTEIN_PREP_PDB_ID_PATTERN)
@@ -284,6 +292,287 @@ def _selection_from_recommendation(
     }
 
 
+def _kind_from_component_id(component_id: str) -> str | None:
+    """Return the Component kind encoded in a transport id, if valid.
+
+    Args:
+        component_id: Selection / recommendation component id.
+
+    Returns:
+        ``chain``, ``ligand``, ``cofactor``, or ``water`` when the id prefix
+        is a known kind, otherwise ``None``.
+    """
+    prefix = component_id.split(":", 1)[0]
+    if prefix in PROTEIN_PREP_COMPONENT_KINDS:
+        return prefix
+    return None
+
+
+def _validate_component_matchers(
+    *,
+    kind: str | None,
+    subtype: str | None,
+    recommendation: str | None,
+    decision: str | None,
+) -> None:
+    """Raise if a table / keep matcher value is not in its allowed set.
+
+    Args:
+        kind: Optional Component kind filter.
+        subtype: Optional subtype filter (any string is allowed).
+        recommendation: Optional frozen analyzer-tag filter.
+        decision: Optional live Selection Decision filter.
+
+    Raises:
+        ValueError: If ``kind``, ``recommendation``, or ``decision`` is set
+            to a value outside its allowed set.
+    """
+    del subtype
+    if kind is not None and kind not in PROTEIN_PREP_COMPONENT_KINDS:
+        allowed = ", ".join(sorted(PROTEIN_PREP_COMPONENT_KINDS))
+        raise ValueError(f"kind must be one of {allowed}, got {kind!r}.")
+    if recommendation is not None and recommendation not in _VALID_DECISIONS:
+        raise ValueError(
+            "recommendation must be 'keep', 'review', or 'skip', "
+            f"got {recommendation!r}."
+        )
+    if decision is not None and decision not in _VALID_DECISIONS:
+        raise ValueError(
+            f"decision must be 'keep', 'review', or 'skip', got {decision!r}."
+        )
+
+
+def _empty_recommendation_dataframe() -> pd.DataFrame:
+    """Return an empty Component table with the canonical column order."""
+    return pd.DataFrame({column: [] for column in PROTEIN_PREP_RECOMMENDATION_COLUMNS})
+
+
+def _rows_to_recommendation_dataframe(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    """Build a Component DataFrame in canonical column order.
+
+    Args:
+        rows: Component row dicts with Recommendation view keys.
+
+    Returns:
+        DataFrame with :data:`PROTEIN_PREP_RECOMMENDATION_COLUMNS`.
+    """
+    if not rows:
+        return _empty_recommendation_dataframe()
+    return pd.DataFrame(rows)[list(PROTEIN_PREP_RECOMMENDATION_COLUMNS)]
+
+
+def _recommendation_rows(
+    payload: dict[str, Any],
+    decisions: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Build table rows from analyzer components and live Decisions.
+
+    Args:
+        payload: Analyzer recommendation dict with ``components``.
+        decisions: Current Selection ``id → decision`` map.
+
+    Returns:
+        One row dict per component, in payload order.
+    """
+    rows: list[dict[str, Any]] = []
+    for raw in payload.get("components") or []:
+        if not isinstance(raw, dict):
+            continue
+        component_id = str(raw.get("id") or "")
+        if not component_id:
+            continue
+        analyzer_tag = raw.get("recommendation")
+        rows.append(
+            {
+                "id": component_id,
+                "kind": raw.get("kind"),
+                "subtype": raw.get("subtype"),
+                "label": raw.get("label"),
+                "recommendation": analyzer_tag,
+                "decision": decisions.get(component_id, analyzer_tag),
+                "reason": raw.get("reason"),
+                "evidence": raw.get("evidence") or {},
+            }
+        )
+    return rows
+
+
+def _selection_rows(decisions: dict[str, str]) -> list[dict[str, Any]]:
+    """Build table rows from a Selection when analyzer evidence is missing.
+
+    Args:
+        decisions: Current Selection ``id → decision`` map.
+
+    Returns:
+        One row dict per Selection id. ``subtype`` / analyzer fields are empty.
+    """
+    rows: list[dict[str, Any]] = []
+    for component_id, live_decision in decisions.items():
+        rows.append(
+            {
+                "id": str(component_id),
+                "kind": _kind_from_component_id(str(component_id)),
+                "subtype": None,
+                "label": None,
+                "recommendation": None,
+                "decision": live_decision,
+                "reason": None,
+                "evidence": {},
+            }
+        )
+    return rows
+
+
+def _filter_recommendation_dataframe(
+    df: pd.DataFrame,
+    *,
+    kind: str | None = None,
+    subtype: str | None = None,
+    recommendation: str | None = None,
+    decision: str | None = None,
+) -> pd.DataFrame:
+    """Return rows matching all provided Component matchers (AND).
+
+    Args:
+        df: Component table.
+        kind: Optional kind equality filter.
+        subtype: Optional subtype equality filter.
+        recommendation: Optional frozen analyzer-tag filter.
+        decision: Optional live Decision filter.
+
+    Returns:
+        Filtered copy with a reset index. Empty when nothing matches.
+
+    Raises:
+        ValueError: If a matcher value is invalid.
+    """
+    _validate_component_matchers(
+        kind=kind,
+        subtype=subtype,
+        recommendation=recommendation,
+        decision=decision,
+    )
+    if df.empty:
+        return df.copy()
+    mask = pd.Series(True, index=df.index)
+    if kind is not None:
+        mask &= df["kind"] == kind
+    if subtype is not None:
+        mask &= df["subtype"] == subtype
+    if recommendation is not None:
+        mask &= df["recommendation"] == recommendation
+    if decision is not None:
+        mask &= df["decision"] == decision
+    return df.loc[mask].reset_index(drop=True)
+
+
+def _ids_from_positional(
+    component_ids: str | Iterable[str] | pd.DataFrame,
+    *,
+    method: str,
+) -> list[str]:
+    """Normalize keep/skip positional ids from a string, iterable, or DataFrame.
+
+    Args:
+        component_ids: Single id, iterable of ids, or DataFrame with ``id``.
+        method: ``keep`` or ``skip``, for error messages.
+
+    Returns:
+        Component ids as strings, preserving order.
+
+    Raises:
+        TypeError: If *component_ids* is a Recommendation view or a mapping.
+        ValueError: If a DataFrame has no ``id`` column.
+    """
+    if isinstance(component_ids, RecommendationView):
+        raise TypeError(PROTEIN_PREP_KEEP_SKIP_VIEW_MSG.format(method=method))
+    if isinstance(component_ids, pd.DataFrame):
+        if "id" not in component_ids.columns:
+            raise ValueError(PROTEIN_PREP_DATAFRAME_ID_COLUMN_MSG)
+        return [str(value) for value in component_ids["id"].tolist()]
+    if isinstance(component_ids, Mapping):
+        raise TypeError(f"{method}() requires component IDs or keyword filters.")
+    if isinstance(component_ids, str):
+        return [component_ids]
+    return [str(component_id) for component_id in component_ids]
+
+
+class RecommendationView:
+    """Callable notebook table of Protein Prep Components.
+
+    Uncalled, Jupyter displays the full inventory. Calling AND-filters rows
+    and returns a :class:`~pandas.DataFrame`. Live Selection Decisions are
+    read from the parent :class:`ProteinPrep` on each access.
+
+    Attributes:
+        raw: Deep copy of the analyzer recommendation payload.
+    """
+
+    def __init__(self, prep: ProteinPrep) -> None:
+        """Bind this view to a ProteinPrep that has analyzer evidence.
+
+        Args:
+            prep: Parent session whose ``_recommendation`` is set.
+        """
+        self._prep = prep
+
+    @property
+    def raw(self) -> dict[str, Any]:
+        """Deep copy of the analyzer recommendation payload."""
+        payload = self._prep._recommendation
+        if payload is None:
+            return {}
+        return deepcopy(payload)
+
+    def _dataframe(self) -> pd.DataFrame:
+        """Return the unfiltered Component table with live Decisions."""
+        payload = self._prep._recommendation
+        if not isinstance(payload, dict):
+            return _empty_recommendation_dataframe()
+        decisions: dict[str, str] = {}
+        if self._prep._selection is not None:
+            decisions = dict(self._prep._selection["decisions"])
+        return _rows_to_recommendation_dataframe(
+            _recommendation_rows(payload, decisions)
+        )
+
+    def __call__(
+        self,
+        *,
+        kind: str | None = None,
+        subtype: str | None = None,
+        recommendation: str | None = None,
+        decision: str | None = None,
+    ) -> pd.DataFrame:
+        """Return a DataFrame of Components matching all provided filters.
+
+        Args:
+            kind: Component kind (``chain``, ``ligand``, ``cofactor``,
+                ``water``).
+            subtype: Analyzer subtype string.
+            recommendation: Frozen analyzer keep/review/skip tag.
+            decision: Live Selection Decision.
+
+        Returns:
+            Filtered Component table. Unfiltered when no kwargs are set.
+        """
+        return _filter_recommendation_dataframe(
+            self._dataframe(),
+            kind=kind,
+            subtype=subtype,
+            recommendation=recommendation,
+            decision=decision,
+        )
+
+    def __repr__(self) -> str:
+        """Return the Component table as text."""
+        return self._dataframe().to_string()
+
+    def _repr_html_(self) -> str:
+        """Return the Component table as HTML for Jupyter."""
+        return self._dataframe()._repr_html_()
+
+
 class ProteinPrep(
     Execution,
     SyncExecutableMixin,
@@ -305,7 +594,8 @@ class ProteinPrep(
         protein: Constructor-only input protein structure.
         pdb_id: Mutable 4-character PDB ID for loop-modelling templates.
         selection: Editable keep/review/skip map. Reads return a copy.
-        recommendation: Read-only analyzer evidence. Reads return a copy.
+        recommendation: Callable Component table, or ``None`` before
+            recommend. Analyzer payload is :attr:`RecommendationView.raw`.
         model_missing_loops: Whether prepare models missing loops.
     """
 
@@ -398,11 +688,11 @@ class ProteinPrep(
         self._selection = _copy_selection(value) if value is not None else None
 
     @property
-    def recommendation(self) -> dict[str, Any] | None:
-        """Analyzer evidence copy, or ``None`` when unavailable."""
+    def recommendation(self) -> RecommendationView | None:
+        """Callable Component table, or ``None`` when analyzer evidence is missing."""
         if self._recommendation is None:
             return None
-        return deepcopy(self._recommendation)
+        return RecommendationView(self)
 
     @property
     def model_missing_loops(self) -> bool:
@@ -436,10 +726,105 @@ class ProteinPrep(
             joined = ", ".join(unresolved)
             raise ValueError(
                 f"Resolve review decisions before preparation: {joined}. "
-                "Use keep([...]) or skip([...])."
+                "Use keep() or skip()."
             )
         if self._model_missing_loops and not self._pdb_id:
             raise ValueError(PROTEIN_PREP_PDB_ID_REQUIRED_MSG)
+
+    def _component_dataframe(self) -> pd.DataFrame:
+        """Return the Component table used by keep/skip matchers.
+
+        Uses analyzer evidence when :attr:`recommendation` is set, otherwise
+        Selection ids with kind inferred from the id prefix.
+
+        Returns:
+            DataFrame with :data:`PROTEIN_PREP_RECOMMENDATION_COLUMNS`.
+        """
+        decisions: dict[str, str] = {}
+        if self._selection is not None:
+            decisions = dict(self._selection["decisions"])
+        if self._recommendation is not None:
+            return _rows_to_recommendation_dataframe(
+                _recommendation_rows(self._recommendation, decisions)
+            )
+        return _rows_to_recommendation_dataframe(_selection_rows(decisions))
+
+    def _ids_matching(
+        self,
+        *,
+        kind: str | None,
+        subtype: str | None,
+        decision: str | None,
+    ) -> list[str]:
+        """Return Selection component ids matching AND keep/skip kwargs.
+
+        Args:
+            kind: Optional Component kind.
+            subtype: Optional subtype. Requires analyzer evidence.
+            decision: Optional live Selection Decision.
+
+        Returns:
+            Matching ids in table order. Empty when nothing matches.
+
+        Raises:
+            ValueError: If a matcher is invalid, or ``subtype`` is used
+                without a recommendation.
+        """
+        if subtype is not None and self._recommendation is None:
+            raise ValueError(PROTEIN_PREP_SUBTYPE_REQUIRES_RECOMMENDATION_MSG)
+        filtered = _filter_recommendation_dataframe(
+            self._component_dataframe(),
+            kind=kind,
+            subtype=subtype,
+            decision=decision,
+        )
+        return [str(value) for value in filtered["id"].tolist()]
+
+    def _apply_decisions(
+        self,
+        component_ids: str | Iterable[str] | pd.DataFrame | None,
+        *,
+        decision_value: str,
+        kind: str | None,
+        subtype: str | None,
+        decision: str | None,
+    ) -> None:
+        """Resolve ids from positional args or matchers, then set Decisions.
+
+        Args:
+            component_ids: Optional ids, DataFrame, or ``None`` when using
+                keyword matchers.
+            decision_value: ``keep`` or ``skip``.
+            kind: Optional kind matcher.
+            subtype: Optional subtype matcher.
+            decision: Optional live Decision matcher.
+
+        Raises:
+            AttributeError: If this object is bound to an execution.
+            TypeError: If positional ids have the wrong type.
+            ValueError: If Selection is missing, styles are mixed, matchers
+                are invalid, or named ids are unknown.
+        """
+        self._require_unbound(decision_value)
+        if self._selection is None:
+            raise ValueError(
+                f"{decision_value}() requires a selection. Call recommend() or "
+                "assign selection first."
+            )
+        has_positional = component_ids is not None
+        has_kwargs = any(value is not None for value in (kind, subtype, decision))
+        if has_positional and has_kwargs:
+            raise ValueError(PROTEIN_PREP_KEEP_SKIP_MIXED_MSG)
+        if not has_positional and not has_kwargs:
+            raise ValueError(
+                PROTEIN_PREP_KEEP_SKIP_EMPTY_MSG.format(method=decision_value)
+            )
+        if has_kwargs:
+            resolved = self._ids_matching(kind=kind, subtype=subtype, decision=decision)
+        else:
+            assert component_ids is not None
+            resolved = _ids_from_positional(component_ids, method=decision_value)
+        self._set_decisions(resolved, decision_value)
 
     def _set_decisions(self, component_ids: Iterable[str], decision: str) -> None:
         """Set one decision for named Selection components.
@@ -449,20 +834,14 @@ class ProteinPrep(
             decision: ``keep`` or ``skip``.
 
         Raises:
-            AttributeError: If this object is bound to an execution.
             TypeError: If *component_ids* is a bare string.
-            ValueError: If Selection is absent or IDs are unknown.
+            ValueError: If IDs are unknown.
         """
-        self._require_unbound(decision)
         if isinstance(component_ids, str):
             raise TypeError(f"{decision}() requires an iterable of component IDs.")
-        if self._selection is None:
-            raise ValueError(
-                f"{decision}() requires a selection. Call recommend() or assign "
-                "selection first."
-            )
-        resolved_ids = [str(component_id) for component_id in component_ids]
+        assert self._selection is not None
         known_ids = self._selection["decisions"]
+        resolved_ids = [str(component_id) for component_id in component_ids]
         unknown_ids = sorted(set(resolved_ids) - set(known_ids))
         if unknown_ids:
             joined = ", ".join(unknown_ids)
@@ -470,21 +849,67 @@ class ProteinPrep(
         for component_id in resolved_ids:
             known_ids[component_id] = decision
 
-    def keep(self, component_ids: Iterable[str]) -> None:
-        """Mark named Selection components to keep.
+    def keep(
+        self,
+        component_ids: str | Iterable[str] | pd.DataFrame | None = None,
+        *,
+        kind: str | None = None,
+        subtype: str | None = None,
+        decision: str | None = None,
+    ) -> Self:
+        """Mark matching Selection components to keep.
+
+        Pass ids (a string, iterable, or DataFrame ``id`` column) *or*
+        keyword matchers, not both. ``kind="water"`` is equivalent to
+        passing every water component id.
 
         Args:
-            component_ids: Iterable of component IDs from :attr:`recommendation`.
-        """
-        self._set_decisions(component_ids, "keep")
+            component_ids: Component ids to keep.
+            kind: Keep every Component of this kind.
+            subtype: Keep every Component of this subtype.
+            decision: Keep every Component with this live Decision.
 
-    def skip(self, component_ids: Iterable[str]) -> None:
-        """Mark named Selection components to skip.
+        Returns:
+            This :class:`ProteinPrep` (for chaining).
+        """
+        self._apply_decisions(
+            component_ids,
+            decision_value="keep",
+            kind=kind,
+            subtype=subtype,
+            decision=decision,
+        )
+        return self
+
+    def skip(
+        self,
+        component_ids: str | Iterable[str] | pd.DataFrame | None = None,
+        *,
+        kind: str | None = None,
+        subtype: str | None = None,
+        decision: str | None = None,
+    ) -> Self:
+        """Mark matching Selection components to skip.
+
+        Same calling styles as :meth:`keep`.
 
         Args:
-            component_ids: Iterable of component IDs from :attr:`recommendation`.
+            component_ids: Component ids to skip.
+            kind: Skip every Component of this kind.
+            subtype: Skip every Component of this subtype.
+            decision: Skip every Component with this live Decision.
+
+        Returns:
+            This :class:`ProteinPrep` (for chaining).
         """
-        self._set_decisions(component_ids, "skip")
+        self._apply_decisions(
+            component_ids,
+            decision_value="skip",
+            kind=kind,
+            subtype=subtype,
+            decision=decision,
+        )
+        return self
 
     def _parameter_rows(self) -> list[tuple[str, str]]:
         """Return ``(name, value)`` rows for text and HTML display.
@@ -506,7 +931,7 @@ class ProteinPrep(
             (
                 "recommendation",
                 (
-                    "available"
+                    f"{len(self._recommendation.get('components') or [])} components"
                     if self._recommendation is not None
                     else PROTEIN_PREP_DISPLAY_NONE
                 ),
@@ -616,13 +1041,16 @@ class ProteinPrep(
             "sync": sync,
         }
 
-    def recommend(self) -> None:
+    def recommend(self) -> RecommendationView:
         """Recommend settings into this object without binding an execution ID.
 
         The platform operation is synchronous and persisted by the backend, but
         its execution ID is deliberately not copied onto this object. Repeated
         calls atomically replace :attr:`recommendation` and :attr:`selection`
         only after a complete recommendation is available.
+
+        Returns:
+            The :class:`RecommendationView` table for this inventory.
 
         Raises:
             AttributeError: If this object is already bound to prepare.
@@ -651,6 +1079,9 @@ class ProteinPrep(
         selection = _selection_from_recommendation(recommendation)
         self._recommendation = deepcopy(recommendation)
         self._selection = selection
+        view = self.recommendation
+        assert view is not None
+        return view
 
     def start(self) -> None:  # ty: ignore[invalid-method-override]
         """Submit preparation asynchronously and bind this object to it.

--- a/src/drug_discovery/protein_prep.py
+++ b/src/drug_discovery/protein_prep.py
@@ -1,27 +1,25 @@
-"""ProteinPrep -- recommend then prepare a protein (async, plus sync loops-off).
+"""Recommend settings and prepare a protein with one mutable configuration.
 
-Protein Prep v2 is two steps on one tool key:
+Protein Prep uses two platform operations behind one user-facing object:
 
 1. ``action="recommend"`` inventories chains, ligands, cofactors, and waters.
-2. ``action="prepare"`` applies a digest-bound frozen Selection, then runs
+2. ``action="prepare"`` applies a digest-bound Selection, then runs
    loop modelling (unless ``model_missing_loops=False``) and protonation.
-
-``start()`` is always valid. ``run()`` is only valid for loops-off prepare
-(blocks until the job finishes).
 
 Usage::
 
-    rec = ProteinPrep(protein)  # pdb_id optional; stored for as_prepare()
-    rec.start()
-    rec.wait()
-    recommendation = rec.get_recommendation()
-
-    prep = rec.as_prepare(model_missing_loops=False)
-    prepared = prep.run()  # in-memory Protein; id is None
+    prep = ProteinPrep(protein)
+    prep.recommend()
+    prep.keep(["chain:A"])
+    prep.skip(["ligand:LIG:A:100"])
+    prep.model_missing_loops = False
+    prepared = prep.run()
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from copy import deepcopy
 from html import escape
 import re
 from typing import Any, Literal, NamedTuple, Self
@@ -39,18 +37,20 @@ from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.client import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS
 from deeporigin.utils.constants import (
+    PROTEIN_PREP_DISPLAY_NONE,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_NO_OUTPUT_PATHS_MSG,
-    PROTEIN_PREP_NO_RECOMMENDATION_MSG,
+    PROTEIN_PREP_NO_RECOMMENDATION_MSG,  # ty:ignore[unresolved-import]
     PROTEIN_PREP_PDB_ID_PATTERN,
-    PROTEIN_PREP_PDB_ID_REQUIRED_MSG,
-    PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,
-    PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG,
+    PROTEIN_PREP_PDB_ID_REQUIRED_MSG,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,  # ty:ignore[unresolved-import]
+    PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG,  # ty:ignore[unresolved-import]
 )
 
 _PDB_ID_RE = re.compile(PROTEIN_PREP_PDB_ID_PATTERN)
 _RESULT_TYPE_PREPARED_PROTEIN = "preparedprotein"
 _VALID_ACTIONS = frozenset({"recommend", "prepare"})
-_VALID_DECISIONS = frozenset({"keep", "skip"})
+_VALID_DECISIONS = frozenset({"keep", "review", "skip"})
+_RESOLVED_DECISIONS = frozenset({"keep", "skip"})
 
 ProteinPrepAction = Literal["recommend", "prepare"]
 
@@ -127,18 +127,18 @@ def _optional_pdb_id(*, protein: Protein, pdb_id: str | None) -> str | None:
 
 
 def _copy_selection(selection: dict[str, Any]) -> dict[str, Any]:
-    """Return a JSON-shape copy of a frozen Selection.
+    """Return a validated JSON-shape copy of a Selection.
 
     Args:
         selection: Selection object with ``source_sha256``, ``analyzer_version``,
             and ``decisions``.
 
     Returns:
-        Copy with string keys and ``keep``/``skip`` decision values.
+        Copy with string keys and ``keep``/``review``/``skip`` decisions.
 
     Raises:
         ValueError: If required keys are missing, ``decisions`` is not an
-            object, or a decision is not ``keep`` or ``skip``.
+            object, or a decision is not ``keep``, ``review``, or ``skip``.
     """
     for key in ("source_sha256", "analyzer_version", "decisions"):
         if key not in selection:
@@ -153,8 +153,8 @@ def _copy_selection(selection: dict[str, Any]) -> dict[str, Any]:
         decision = str(raw_decision)
         if decision not in _VALID_DECISIONS:
             raise ValueError(
-                f"selection.decisions[{component_id!r}] must be 'keep' or "
-                f"'skip', got {raw_decision!r}."
+                f"selection.decisions[{component_id!r}] must be 'keep', "
+                f"'review', or 'skip', got {raw_decision!r}."
             )
         decisions[str(component_id)] = decision
     return {
@@ -171,16 +171,17 @@ def _format_selection_display(selection: dict[str, Any] | None) -> str:
         selection: Current selection, or ``None`` on a recommend run.
 
     Returns:
-        Count of keep/skip decisions, or ``(none)`` when unset.
+        Count of keep/review/skip decisions, or ``(none)`` when unset.
     """
     if selection is None:
-        return "(none)"
+        return PROTEIN_PREP_DISPLAY_NONE
     decisions = selection.get("decisions") or {}
     if not isinstance(decisions, dict) or not decisions:
-        return "(none)"
+        return PROTEIN_PREP_DISPLAY_NONE
     keep_n = sum(1 for value in decisions.values() if value == "keep")
+    review_n = sum(1 for value in decisions.values() if value == "review")
     skip_n = sum(1 for value in decisions.values() if value == "skip")
-    return f"{keep_n} keep, {skip_n} skip"
+    return f"{keep_n} keep, {review_n} review, {skip_n} skip"
 
 
 def _protein_tool_input(protein: Protein) -> dict[str, Any]:
@@ -237,35 +238,21 @@ def _protein_from_prepared_data(
     )
 
 
-def selection_from_recommendation(
+def _selection_from_recommendation(
     recommendation: dict[str, Any],
-    *,
-    resolve_review_as: str = "skip",
 ) -> dict[str, Any]:
-    """Build a frozen Selection from a recommend ``jobOutputs`` payload.
-
-    Each component's tri-state recommendation becomes a binary ``keep`` or
-    ``skip``. Items marked ``review`` are mapped with *resolve_review_as*
-    (default ``skip``).
+    """Build an editable Selection from recommendation output.
 
     Args:
         recommendation: ``jobOutputs.recommendation`` dict (``source_sha256``,
             ``analyzer_version``, ``components``).
-        resolve_review_as: Decision to apply to every ``review`` component.
-            Must be ``keep`` or ``skip``.
-
     Returns:
         Selection with ``source_sha256``, ``analyzer_version``, and
-        ``decisions``.
+        tri-state ``decisions``.
 
     Raises:
-        ValueError: If the recommendation is missing required fields, a
-            component has no id, or *resolve_review_as* is invalid.
+        ValueError: If required data is missing or a component is invalid.
     """
-    if resolve_review_as not in _VALID_DECISIONS:
-        raise ValueError(
-            f"resolve_review_as must be 'keep' or 'skip', got {resolve_review_as!r}."
-        )
     source_sha256 = recommendation.get("source_sha256")
     analyzer_version = recommendation.get("analyzer_version")
     components = recommendation.get("components")
@@ -284,8 +271,6 @@ def selection_from_recommendation(
         if not component_id or not str(component_id).strip():
             raise ValueError(f"recommendation.components[{index}] must include id.")
         rec = str(raw.get("recommendation") or "")
-        if rec == "review":
-            rec = resolve_review_as
         if rec not in _VALID_DECISIONS:
             raise ValueError(
                 f"recommendation.components[{index}] recommendation must be "
@@ -305,27 +290,23 @@ class ProteinPrep(
     AsyncExecutableMixin,
     NotebookWatchMixin,
 ):
-    """Prepare a protein via ``deeporigin.protein-prep``.
+    """Recommend settings and prepare a protein.
 
-    :meth:`start` is always valid. With no ``selection``, it runs
-    ``action=recommend``. After that job finishes, :meth:`as_prepare` (or
-    :meth:`from_recommendation`) builds a prepare run.
+    :meth:`recommend` blocks, updates :attr:`recommendation` and
+    :attr:`selection`, and deliberately leaves :attr:`id` unset. Resolve
+    ``review`` decisions with :meth:`keep` and :meth:`skip`, then call
+    :meth:`run` for blocking loops-off preparation or :meth:`start` for
+    asynchronous preparation.
 
-    :meth:`run` is only valid for prepare with ``model_missing_loops=False``
-    (skips loop modelling). It blocks until the job finishes and returns an
-    in-memory :class:`Protein` via :meth:`get_results`. Recommend and
-    loops-on prepare must use :meth:`start`. Quoting is unused (billing is
-    skipped).
-
-    Displaying the object (``print(prep)`` or a notebook cell) lists every
-    input you can set and its current value.
+    A prepare submission binds the object to its durable execution. Once
+    :attr:`id` is set, configuration is permanently frozen.
 
     Attributes:
-        protein: Input protein structure (unchanged after the run).
-        action: ``recommend`` or ``prepare``.
-        pdb_id: 4-character PDB ID for loop-modelling templates (prepare).
-        selection: Frozen keep/skip map (prepare only).
-        model_missing_loops: When ``False``, prepare skips loop modelling.
+        protein: Constructor-only input protein structure.
+        pdb_id: Mutable 4-character PDB ID for loop-modelling templates.
+        selection: Editable keep/review/skip map. Reads return a copy.
+        recommendation: Read-only analyzer evidence. Reads return a copy.
+        model_missing_loops: Whether prepare models missing loops.
     """
 
     tool_key: str = TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"]
@@ -335,7 +316,6 @@ class ProteinPrep(
         self,
         protein: Protein,
         *,
-        action: ProteinPrepAction | None = None,
         pdb_id: str | None = None,
         selection: dict[str, Any] | None = None,
         model_missing_loops: bool = True,
@@ -344,77 +324,167 @@ class ProteinPrep(
     ) -> None:
         """Create a ProteinPrep for the given protein.
 
-        With no ``selection``, this is a recommend run. Pass ``selection``
-        (or use :meth:`as_prepare`) for prepare.
+        Call :meth:`recommend` to populate a Selection, or pass an existing
+        Selection and prepare immediately.
 
         Args:
-            protein: Protein structure to inventory or prepare.
-            action: ``recommend`` or ``prepare``. Inferred from whether
-                ``selection`` is set when omitted.
+            protein: Protein structure to inventory or prepare. It cannot be
+                replaced after construction.
             pdb_id: 4-character PDB ID for loop modelling. Inferred from
-                ``protein.pdb_id`` when omitted. Required for prepare unless
-                ``model_missing_loops`` is ``False``. Stored on recommend runs
-                so :meth:`as_prepare` can reuse it.
-            selection: Digest-bound frozen Selection (``source_sha256``,
-                ``analyzer_version``, ``decisions``). Required for prepare.
+                ``protein.pdb_id`` when omitted.
+            selection: Optional digest-bound Selection with ``source_sha256``,
+                ``analyzer_version``, and ``decisions``.
             model_missing_loops: When ``False``, skip loop modelling and do
-                not require ``pdb_id``. Ignored for recommend (must stay
-                ``True``).
+                not require ``pdb_id``.
             tool_version: Platform tool version pin.
             client: Optional API client. Uses the default if not provided.
 
         Raises:
-            ValueError: If ``action``/``selection`` disagree, ``pdb_id`` is
-                missing for loops-on prepare, ``pdb_id`` is malformed, or
-                ``selection`` is invalid.
+            ValueError: If ``pdb_id`` or ``selection`` is invalid.
         """
         super().__init__(client=client)
         self.tool_version = tool_version
         self._protein = protein
-        resolved_action = _resolve_action(action=action, selection=selection)
-        if resolved_action == "recommend" and not model_missing_loops:
-            raise ValueError(
-                "model_missing_loops=False requires action='prepare' and a "
-                "selection. Run recommend first, then "
-                "as_prepare(model_missing_loops=False)."
-            )
-        self._action: ProteinPrepAction = resolved_action
+        self._operation_kind: ProteinPrepAction | None = None
         self._pdb_id = _optional_pdb_id(protein=protein, pdb_id=pdb_id)
         self._selection = _copy_selection(selection) if selection is not None else None
-        self._model_missing_loops = (
-            True if resolved_action == "recommend" else model_missing_loops
-        )
-        if (
-            resolved_action == "prepare"
-            and self._model_missing_loops
-            and not self._pdb_id
-        ):
-            raise ValueError(PROTEIN_PREP_PDB_ID_REQUIRED_MSG)
+        self._recommendation: dict[str, Any] | None = None
+        self._model_missing_loops = model_missing_loops
 
     @property
     def protein(self) -> Protein:
-        """Input protein structure used for recommendation or preparation."""
+        """Constructor-only protein used for recommendation and preparation."""
         return self._protein
 
-    @property
-    def action(self) -> str:
-        """``recommend`` or ``prepare``."""
-        return self._action
+    def _require_unbound(self, attribute: str) -> None:
+        """Raise when configuration mutation follows durable submission.
+
+        Args:
+            attribute: Configuration attribute or operation being changed.
+
+        Raises:
+            AttributeError: If this object has a durable execution ID.
+        """
+        if self.id is not None:
+            raise AttributeError(
+                f"cannot assign to {attribute!r}: execution id is already set"
+            )
 
     @property
     def pdb_id(self) -> str | None:
         """4-character PDB ID used for loop-modelling templates, if set."""
         return self._pdb_id
 
+    @pdb_id.setter
+    def pdb_id(self, value: str | None) -> None:
+        """Set or clear ``pdb_id`` before this execution is submitted."""
+        self._require_unbound("pdb_id")
+        if value is None or not str(value).strip():
+            self._pdb_id = None
+            return
+        self._pdb_id = _normalize_pdb_id(str(value))
+
     @property
     def selection(self) -> dict[str, Any] | None:
-        """Frozen Selection for prepare; ``None`` on a recommend run."""
-        return self._selection
+        """Editable Selection copy, or ``None`` before recommendation."""
+        if self._selection is None:
+            return None
+        return _copy_selection(self._selection)
+
+    @selection.setter
+    def selection(self, value: dict[str, Any] | None) -> None:
+        """Set or clear a copied Selection before prepare submission."""
+        self._require_unbound("selection")
+        self._selection = _copy_selection(value) if value is not None else None
+
+    @property
+    def recommendation(self) -> dict[str, Any] | None:
+        """Analyzer evidence copy, or ``None`` when unavailable."""
+        if self._recommendation is None:
+            return None
+        return deepcopy(self._recommendation)
 
     @property
     def model_missing_loops(self) -> bool:
         """Whether prepare will run loop modelling (unused for recommend)."""
         return self._model_missing_loops
+
+    @model_missing_loops.setter
+    def model_missing_loops(self, value: bool) -> None:
+        """Set the loop-modelling flag before this execution is submitted."""
+        self._require_unbound("model_missing_loops")
+        self._model_missing_loops = bool(value)
+
+    def _validate_for_submit(self) -> None:
+        """Raise if current settings cannot prepare the protein.
+
+        Raises:
+            ValueError: If Selection is absent or unresolved, or loops-on
+                prepare has no ``pdb_id``.
+        """
+        if self._selection is None:
+            raise ValueError(
+                "ProteinPrep has no selection. Call recommend() or assign selection "
+                "before run() or start()."
+            )
+        unresolved = sorted(
+            component_id
+            for component_id, decision in self._selection["decisions"].items()
+            if decision == "review"
+        )
+        if unresolved:
+            joined = ", ".join(unresolved)
+            raise ValueError(
+                f"Resolve review decisions before preparation: {joined}. "
+                "Use keep([...]) or skip([...])."
+            )
+        if self._model_missing_loops and not self._pdb_id:
+            raise ValueError(PROTEIN_PREP_PDB_ID_REQUIRED_MSG)
+
+    def _set_decisions(self, component_ids: Iterable[str], decision: str) -> None:
+        """Set one decision for named Selection components.
+
+        Args:
+            component_ids: Iterable of component IDs to update.
+            decision: ``keep`` or ``skip``.
+
+        Raises:
+            AttributeError: If this object is bound to an execution.
+            TypeError: If *component_ids* is a bare string.
+            ValueError: If Selection is absent or IDs are unknown.
+        """
+        self._require_unbound(decision)
+        if isinstance(component_ids, str):
+            raise TypeError(f"{decision}() requires an iterable of component IDs.")
+        if self._selection is None:
+            raise ValueError(
+                f"{decision}() requires a selection. Call recommend() or assign "
+                "selection first."
+            )
+        resolved_ids = [str(component_id) for component_id in component_ids]
+        known_ids = self._selection["decisions"]
+        unknown_ids = sorted(set(resolved_ids) - set(known_ids))
+        if unknown_ids:
+            joined = ", ".join(unknown_ids)
+            raise ValueError(f"Unknown Selection component IDs: {joined}.")
+        for component_id in resolved_ids:
+            known_ids[component_id] = decision
+
+    def keep(self, component_ids: Iterable[str]) -> None:
+        """Mark named Selection components to keep.
+
+        Args:
+            component_ids: Iterable of component IDs from :attr:`recommendation`.
+        """
+        self._set_decisions(component_ids, "keep")
+
+    def skip(self, component_ids: Iterable[str]) -> None:
+        """Mark named Selection components to skip.
+
+        Args:
+            component_ids: Iterable of component IDs from :attr:`recommendation`.
+        """
+        self._set_decisions(component_ids, "skip")
 
     def _parameter_rows(self) -> list[tuple[str, str]]:
         """Return ``(name, value)`` rows for text and HTML display.
@@ -424,13 +494,23 @@ class ProteinPrep(
         """
         rows: list[tuple[str, str]] = [
             ("protein", _protein_display_value(self.protein)),
-            ("action", self.action),
-            ("pdb_id", self.pdb_id if self.pdb_id else "(none)"),
+            (
+                "pdb_id",
+                self.pdb_id if self.pdb_id else PROTEIN_PREP_DISPLAY_NONE,
+            ),
             (
                 "model_missing_loops",
                 str(self.model_missing_loops),
             ),
             ("selection", _format_selection_display(self.selection)),
+            (
+                "recommendation",
+                (
+                    "available"
+                    if self._recommendation is not None
+                    else PROTEIN_PREP_DISPLAY_NONE
+                ),
+            ),
             ("tool_version", str(self.tool_version)),
         ]
         if self.name:
@@ -440,6 +520,9 @@ class ProteinPrep(
         status = getattr(self, "status", None)
         if status:
             rows.append(("status", str(status)))
+        progress = getattr(self, "progress", None)
+        if progress:
+            rows.append(("progress", str(progress)))
         return rows
 
     def __repr__(self) -> str:
@@ -491,10 +574,10 @@ class ProteinPrep(
         self._protein.sync(lazy=True, client=self.client)
         self._protein.ensure_remote_path(client=self.client, label="Protein")
 
-    def _make_payload(
+    def _make_protein_prep_payload(
         self,
         *,
-        approve_amount: int | None,
+        action: ProteinPrepAction,
         sync: bool,
     ) -> dict[str, Any]:
         """Build the POST body for ``executions.create``.
@@ -504,20 +587,19 @@ class ProteinPrep(
         ``sync`` property.
 
         Args:
-            approve_amount: Spend cap; omitted from the body when ``None``.
-            sync: ``True`` for :meth:`run` (blocking create); ``False`` for
-                :meth:`start`.
+            action: Internal platform operation.
+            sync: Whether create blocks until completion.
 
         Returns:
             Payload for ``client.executions.create``.
         """
         inputs: dict[str, Any] = {
-            "action": self._action,
+            "action": action,
             "protein": _protein_tool_input(self._protein),
         }
-        if self._action == "prepare":
-            if self._selection is None:
-                raise ValueError("prepare requires a selection.")
+        if action == "prepare":
+            self._validate_for_submit()
+            assert self._selection is not None
             inputs["selection"] = {
                 "source_sha256": self._selection["source_sha256"],
                 "analyzer_version": self._selection["analyzer_version"],
@@ -527,184 +609,101 @@ class ProteinPrep(
                 inputs["model_missing_loops"] = False
             if self._pdb_id:
                 inputs["pdb_id"] = self._pdb_id
-        payload: dict[str, Any] = {
+        return {
             "inputs": inputs,
             "outputs": {},
             "metadata": {},
             "sync": sync,
         }
-        if approve_amount is not None:
-            payload["approveAmount"] = approve_amount
-        return payload
 
-    def _start_impl(self, *, approve_amount: int | None = None, **kwargs: Any) -> None:
-        """Submit protein prep as a persisted async execution.
+    def recommend(self) -> None:
+        """Recommend settings into this object without binding an execution ID.
 
-        Args:
-            approve_amount: Spend cap forwarded to the platform. ``None`` omits
-                the field (the tool has no quote).
-            **kwargs: Unused; accepted for mixin compatibility.
+        The platform operation is synchronous and persisted by the backend, but
+        its execution ID is deliberately not copied onto this object. Repeated
+        calls atomically replace :attr:`recommendation` and :attr:`selection`
+        only after a complete recommendation is available.
+
+        Raises:
+            AttributeError: If this object is already bound to prepare.
+            DeepOriginException: If recommendation output is unavailable.
         """
-        _ = kwargs
+        self._require_unbound("recommend")
+        self._ensure_protein_remote()
+        dto = self._create_execution(
+            data=self._make_protein_prep_payload(action="recommend", sync=True),
+        )
+        recommendation = self._recommendation_from_dto(dto)
+        execution_id = dto.get("executionId")
+        if recommendation is None and execution_id is not None:
+            try:
+                fetched = self.client.executions.get(  # ty:ignore[unresolved-attribute]
+                    str(execution_id)
+                )
+            except Exception:
+                fetched = None
+            recommendation = self._recommendation_from_dto(fetched)
+        if recommendation is None:
+            raise DeepOriginException(
+                title="Could not load protein recommendation",
+                message=PROTEIN_PREP_NO_RECOMMENDATION_MSG,
+            )
+        selection = _selection_from_recommendation(recommendation)
+        self._recommendation = deepcopy(recommendation)
+        self._selection = selection
+
+    def start(self) -> None:  # ty: ignore[invalid-method-override]
+        """Submit preparation asynchronously and bind this object to it.
+
+        Raises:
+            ValueError: If already submitted or settings cannot prepare.
+        """
+        if self.id is not None or self.status is not None:
+            raise ValueError("Cannot start: this ProteinPrep is already bound.")
+        self._validate_for_submit()
         self._ensure_protein_remote()
         execution_dto = self._create_execution(
-            data=self._make_payload(approve_amount=approve_amount, sync=False),
+            data=self._make_protein_prep_payload(action="prepare", sync=False),
         )
         if execution_dto.get("executionId") is None:
             raise ValueError("Execution response must contain 'executionId'") from None
+        self._operation_kind = "prepare"
         self.update_from_dto(execution_dto)
 
     def _require_loops_off_prepare(self) -> None:
         """Raise unless this instance may ``run()``.
 
-        ``run()`` is only legal for ``action='prepare'`` with
-        ``model_missing_loops=False``.
+        ``run()`` is only legal with ``model_missing_loops=False``.
 
         Raises:
-            ValueError: If this is a recommend run or loops-on prepare.
+            ValueError: If loop modelling is enabled.
         """
-        if self._action != "prepare" or self._model_missing_loops:
+        if self._model_missing_loops:
             raise ValueError(PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG)
 
-    def run(
-        self,
-        *,
-        quote: bool = False,
-        approve_amount: int | None = None,
-    ) -> Protein | None:
+    def run(self) -> Protein:
         """Execute loops-off prepare synchronously (blocking).
 
-        Only valid when :attr:`action` is ``prepare`` and
-        :attr:`model_missing_loops` is ``False``. Recommend and loops-on
-        prepare must use :meth:`start`.
-
-        Pass ``quote=True`` (or ``approve_amount=0``) to request a cost
-        estimate only. Billing is skipped for this tool, so quoting is
-        unused. If the platform returns a ``Quoted`` DTO, ``None`` is
-        returned.
-
-        Args:
-            quote: Shorthand for ``approve_amount=0``.
-            approve_amount: Spend cap forwarded to the platform as
-                ``approveAmount``.
+        Only valid when :attr:`model_missing_loops` is ``False``.
 
         Returns:
-            An in-memory :class:`Protein`, or ``None`` when the platform
-            responds with ``Quoted`` status.
+            An in-memory prepared :class:`Protein`.
 
         Raises:
-            ValueError: If this is not loops-off prepare.
+            ValueError: If already submitted or this is not loops-off prepare.
             DeepOriginException: If no prepared PDB path could be loaded.
         """
+        if self.id is not None or self.status is not None:
+            raise ValueError("Cannot run: this ProteinPrep is already bound.")
         self._require_loops_off_prepare()
+        self._validate_for_submit()
         self._ensure_protein_remote()
-        resolved_amount = 0 if quote else approve_amount
         dto = self._create_execution(
-            data=self._make_payload(approve_amount=resolved_amount, sync=True),
+            data=self._make_protein_prep_payload(action="prepare", sync=True),
         )
+        self._operation_kind = "prepare"
         self.update_from_dto(dto)
-
-        if self.status == "Quoted":
-            return None
-
         return self.get_results(dto)
-
-    @staticmethod
-    def selection_from_recommendation(
-        recommendation: dict[str, Any],
-        *,
-        resolve_review_as: str = "skip",
-    ) -> dict[str, Any]:
-        """Build a frozen Selection from a recommend result.
-
-        See :func:`selection_from_recommendation`.
-        """
-        return selection_from_recommendation(
-            recommendation,
-            resolve_review_as=resolve_review_as,
-        )
-
-    @classmethod
-    def from_recommendation(
-        cls,
-        protein: Protein,
-        recommendation: dict[str, Any],
-        *,
-        pdb_id: str | None = None,
-        model_missing_loops: bool = True,
-        resolve_review_as: str = "skip",
-        tool_version: str = TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
-        client: DeepOriginClient | None = None,
-    ) -> Self:
-        """Build a prepare ``ProteinPrep`` from a recommend payload.
-
-        Args:
-            protein: Same protein that was recommended (same structure bytes).
-            recommendation: ``jobOutputs.recommendation`` dict.
-            pdb_id: PDB ID for loop modelling. Inferred from
-                ``protein.pdb_id`` when omitted.
-            model_missing_loops: When ``False``, skip loop modelling.
-            resolve_review_as: Binary decision for every ``review`` component.
-            tool_version: Platform tool version pin.
-            client: Optional API client.
-
-        Returns:
-            A ``ProteinPrep`` with ``action='prepare'`` ready for ``start()``
-            or, when ``model_missing_loops=False``, ``run()``.
-        """
-        selection = selection_from_recommendation(
-            recommendation,
-            resolve_review_as=resolve_review_as,
-        )
-        return cls(
-            protein,
-            action="prepare",
-            pdb_id=pdb_id,
-            selection=selection,
-            model_missing_loops=model_missing_loops,
-            tool_version=tool_version,
-            client=client,
-        )
-
-    def as_prepare(
-        self,
-        *,
-        pdb_id: str | None = None,
-        model_missing_loops: bool = True,
-        resolve_review_as: str = "skip",
-    ) -> ProteinPrep:
-        """Return a prepare ``ProteinPrep`` from this completed recommend run.
-
-        Args:
-            pdb_id: PDB ID for loop modelling. Defaults to this instance's
-                ``pdb_id`` (constructor / ``protein.pdb_id``).
-            model_missing_loops: When ``False``, skip loop modelling.
-            resolve_review_as: Binary decision for every ``review`` component.
-
-        Returns:
-            A new ``ProteinPrep`` with ``action='prepare'``. Call ``run()``
-            when ``model_missing_loops=False``, or ``start()`` otherwise.
-
-        Raises:
-            ValueError: If this instance is not a recommend run, or no
-                recommendation is available yet.
-        """
-        if self._action != "recommend":
-            raise ValueError(
-                "as_prepare() requires a recommend run. Construct ProteinPrep "
-                "without selection and call start() first."
-            )
-        recommendation = self.get_recommendation()
-        resolved_pdb_id = pdb_id if pdb_id is not None else self._pdb_id
-        return type(self).from_recommendation(
-            self._protein,
-            recommendation,
-            pdb_id=resolved_pdb_id,
-            model_missing_loops=model_missing_loops,
-            resolve_review_as=resolve_review_as,
-            tool_version=self.tool_version,
-            client=self.client,
-        )
 
     @staticmethod
     def _parse_inputs_dict(inputs: dict[str, Any]) -> _ParsedInputs:
@@ -771,9 +770,8 @@ class ProteinPrep(
     ) -> Self:
         """Construct a ``ProteinPrep`` from a tools execution DTO.
 
-        Rehydrates ``protein``, ``action``, ``pdb_id``, ``selection``, and
-        ``model_missing_loops`` from ``userInputs`` (falling back to
-        ``inputs``).
+        Rehydrates historical recommendation and preparation executions while
+        keeping their operation kind private.
 
         Args:
             dto: Execution payload (same shape as ``client.executions.get``).
@@ -813,9 +811,14 @@ class ProteinPrep(
                 structure=None,
                 remote_path=file_path,
             )
-        instance._action = parsed.action
+        instance._operation_kind = parsed.action
         instance._pdb_id = parsed.pdb_id
         instance._selection = parsed.selection
+        instance._recommendation = instance._recommendation_from_dto(dto)
+        if instance._selection is None and instance._recommendation is not None:
+            instance._selection = _selection_from_recommendation(
+                instance._recommendation
+            )
         instance._model_missing_loops = parsed.model_missing_loops
         return instance
 
@@ -851,39 +854,6 @@ class ProteinPrep(
         return None
 
     @beartype
-    def get_recommendation(self, dto: dict[str, Any] | None = None) -> dict[str, Any]:
-        """Load the component inventory from a recommend run.
-
-        Args:
-            dto: Optional execution payload. Passing it avoids an extra GET
-                when ``jobOutputs.recommendation`` is already in hand.
-
-        Returns:
-            The ``recommendation`` object (``source_sha256``,
-            ``analyzer_version``, ``components``, ``chain_id_mapping``).
-
-        Raises:
-            ValueError: If :attr:`id` is unset.
-            DeepOriginException: If no recommendation could be loaded.
-        """
-        exec_id = self._ensure_id()
-        for candidate in (dto, self._dto):
-            recommendation = self._recommendation_from_dto(candidate)
-            if recommendation is not None:
-                return recommendation
-        try:
-            exec_dto = self.client.executions.get(exec_id)  # ty:ignore[unresolved-attribute]
-        except Exception:
-            exec_dto = None
-        recommendation = self._recommendation_from_dto(exec_dto)
-        if recommendation is not None:
-            return recommendation
-        raise DeepOriginException(
-            title="Could not load protein recommendation",
-            message=PROTEIN_PREP_NO_RECOMMENDATION_MSG,
-        )
-
-    @beartype
     def get_results(self, dto: dict[str, Any] | None = None) -> Protein:
         """Load the prepared protein as an in-memory :class:`Protein`.
 
@@ -906,7 +876,7 @@ class ProteinPrep(
                 PDB path could be loaded.
         """
         exec_id = self._ensure_id()
-        if self._action == "recommend":
+        if self._operation_kind == "recommend":
             raise DeepOriginException(
                 title="Could not load prepared protein",
                 message=PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,
@@ -941,37 +911,3 @@ class ProteinPrep(
             title="Could not load prepared protein",
             message=PROTEIN_PREP_NO_OUTPUT_PATHS_MSG,
         )
-
-
-def _resolve_action(
-    *,
-    action: str | None,
-    selection: dict[str, Any] | None,
-) -> ProteinPrepAction:
-    """Infer or validate ``recommend`` vs ``prepare``.
-
-    Args:
-        action: Explicit action, or ``None`` to infer from *selection*.
-        selection: Frozen Selection, or ``None`` for recommend.
-
-    Returns:
-        ``recommend`` or ``prepare``.
-
-    Raises:
-        ValueError: If *action* is unknown, or *action* and *selection*
-            disagree.
-    """
-    if action is not None and action not in _VALID_ACTIONS:
-        raise ValueError(f"action must be 'recommend' or 'prepare', got {action!r}.")
-    if action == "recommend":
-        if selection is not None:
-            raise ValueError("action='recommend' does not accept a selection.")
-        return "recommend"
-    if action == "prepare":
-        if selection is None:
-            raise ValueError(
-                "action='prepare' requires a selection. Run recommend first, "
-                "or pass selection= from selection_from_recommendation()."
-            )
-        return "prepare"
-    return "prepare" if selection is not None else "recommend"

--- a/src/drug_discovery/protein_prep.py
+++ b/src/drug_discovery/protein_prep.py
@@ -1,22 +1,38 @@
-"""ProteinPrep -- async-only execution for expert protein preparation.
+"""ProteinPrep -- recommend then prepare a protein (async, plus sync loops-off).
+
+Protein Prep v2 is two steps on one tool key:
+
+1. ``action="recommend"`` inventories chains, ligands, cofactors, and waters.
+2. ``action="prepare"`` applies a digest-bound frozen Selection, then runs
+   loop modelling (unless ``model_missing_loops=False``) and protonation.
+
+``start()`` is always valid. ``run()`` is only valid for loops-off prepare
+(blocks until the job finishes).
 
 Usage::
 
-    prep = ProteinPrep(protein, pdb_id="1EBY")  # pdb_id inferred if protein.pdb_id is set
-    prep.start()
-    prep.wait()
-    prepared = prep.get_results()  # in-memory Protein; id is None
+    rec = ProteinPrep(protein)  # pdb_id optional; stored for as_prepare()
+    rec.start()
+    rec.wait()
+    recommendation = rec.get_recommendation()
+
+    prep = rec.as_prepare(model_missing_loops=False)
+    prepared = prep.run()  # in-memory Protein; id is None
 """
 
 from __future__ import annotations
 
+from html import escape
 import re
-from typing import Any, Self
+from typing import Any, Literal, NamedTuple, Self
 
 from beartype import beartype
 
 from deeporigin.drug_discovery.execution import Execution
-from deeporigin.drug_discovery.execution_mixins import AsyncExecutableMixin
+from deeporigin.drug_discovery.execution_mixins import (
+    AsyncExecutableMixin,
+    SyncExecutableMixin,
+)
 from deeporigin.drug_discovery.notebook_watch_mixin import NotebookWatchMixin
 from deeporigin.drug_discovery.structures.protein import Protein
 from deeporigin.exceptions import DeepOriginException
@@ -24,38 +40,64 @@ from deeporigin.platform.client import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS
 from deeporigin.utils.constants import (
     PROTEIN_PREP_NO_OUTPUT_PATHS_MSG,
+    PROTEIN_PREP_NO_RECOMMENDATION_MSG,
     PROTEIN_PREP_PDB_ID_PATTERN,
+    PROTEIN_PREP_PDB_ID_REQUIRED_MSG,
+    PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,
+    PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG,
 )
 
 _PDB_ID_RE = re.compile(PROTEIN_PREP_PDB_ID_PATTERN)
 _RESULT_TYPE_PREPARED_PROTEIN = "preparedprotein"
+_VALID_ACTIONS = frozenset({"recommend", "prepare"})
+_VALID_DECISIONS = frozenset({"keep", "skip"})
+
+ProteinPrepAction = Literal["recommend", "prepare"]
 
 
-def _copy_str_list(values: list[str] | None) -> list[str]:
-    """Return a shallow copy of *values*, or an empty list when ``None``."""
-    return list(values) if values is not None else []
+class _ParsedInputs(NamedTuple):
+    """Fields reconstructed from a Protein Prep execution ``userInputs`` dict."""
+
+    protein: dict[str, Any]
+    action: ProteinPrepAction
+    pdb_id: str | None
+    selection: dict[str, Any] | None
+    model_missing_loops: bool
 
 
-def _resolve_pdb_id(*, protein: Protein, pdb_id: str | None) -> str:
-    """Return a 4-character PDB ID from *pdb_id* or ``protein.pdb_id``.
+def _protein_display_value(protein: Protein) -> str:
+    """Return a short identity string for a protein used as ProteinPrep input.
 
     Args:
-        protein: Input protein that may already carry ``pdb_id``.
-        pdb_id: Explicit override; used when set.
+        protein: Input protein.
+
+    Returns:
+        Protein name, plus ``id`` and ``pdb_id`` when those are set.
+    """
+    extras: list[str] = []
+    if protein.id:
+        extras.append(f"id={protein.id!r}")
+    if protein.pdb_id:
+        extras.append(f"pdb_id={protein.pdb_id!r}")
+    name = protein.name or "(unnamed)"
+    if extras:
+        return f"{name} ({', '.join(extras)})"
+    return name
+
+
+def _normalize_pdb_id(raw: str) -> str:
+    """Return a validated 4-character PDB identifier.
+
+    Args:
+        raw: Candidate PDB ID.
 
     Returns:
         Stripped 4-character alphanumeric PDB identifier.
 
     Raises:
-        ValueError: If neither source is set, or the value does not match
+        ValueError: If ``raw`` does not match
             :data:`~deeporigin.utils.constants.PROTEIN_PREP_PDB_ID_PATTERN`.
     """
-    raw = pdb_id if pdb_id is not None else protein.pdb_id
-    if raw is None or not str(raw).strip():
-        raise ValueError(
-            "pdb_id is required when protein.pdb_id is not set. "
-            "Pass pdb_id= as a 4-character PDB identifier for loop modelling."
-        )
     resolved = str(raw).strip()
     if _PDB_ID_RE.fullmatch(resolved) is None:
         raise ValueError(
@@ -63,6 +105,103 @@ def _resolve_pdb_id(*, protein: Protein, pdb_id: str | None) -> str:
             f"got {resolved!r}."
         )
     return resolved
+
+
+def _optional_pdb_id(*, protein: Protein, pdb_id: str | None) -> str | None:
+    """Return a PDB ID from *pdb_id* or ``protein.pdb_id``, or ``None``.
+
+    Args:
+        protein: Input protein that may already carry ``pdb_id``.
+        pdb_id: Explicit override; used when set.
+
+    Returns:
+        Validated PDB ID, or ``None`` when neither source is set.
+
+    Raises:
+        ValueError: If a value is present but is not 4 alphanumeric characters.
+    """
+    raw = pdb_id if pdb_id is not None else protein.pdb_id
+    if raw is None or not str(raw).strip():
+        return None
+    return _normalize_pdb_id(str(raw))
+
+
+def _copy_selection(selection: dict[str, Any]) -> dict[str, Any]:
+    """Return a JSON-shape copy of a frozen Selection.
+
+    Args:
+        selection: Selection object with ``source_sha256``, ``analyzer_version``,
+            and ``decisions``.
+
+    Returns:
+        Copy with string keys and ``keep``/``skip`` decision values.
+
+    Raises:
+        ValueError: If required keys are missing, ``decisions`` is not an
+            object, or a decision is not ``keep`` or ``skip``.
+    """
+    for key in ("source_sha256", "analyzer_version", "decisions"):
+        if key not in selection:
+            raise ValueError(f"selection must include {key!r}.")
+    decisions_raw = selection["decisions"]
+    if not isinstance(decisions_raw, dict):
+        raise ValueError("selection.decisions must be an object.")
+    if not decisions_raw:
+        raise ValueError("selection.decisions must not be empty.")
+    decisions: dict[str, str] = {}
+    for component_id, raw_decision in decisions_raw.items():
+        decision = str(raw_decision)
+        if decision not in _VALID_DECISIONS:
+            raise ValueError(
+                f"selection.decisions[{component_id!r}] must be 'keep' or "
+                f"'skip', got {raw_decision!r}."
+            )
+        decisions[str(component_id)] = decision
+    return {
+        "source_sha256": str(selection["source_sha256"]),
+        "analyzer_version": str(selection["analyzer_version"]),
+        "decisions": decisions,
+    }
+
+
+def _format_selection_display(selection: dict[str, Any] | None) -> str:
+    """Format a frozen Selection for ProteinPrep display.
+
+    Args:
+        selection: Current selection, or ``None`` on a recommend run.
+
+    Returns:
+        Count of keep/skip decisions, or ``(none)`` when unset.
+    """
+    if selection is None:
+        return "(none)"
+    decisions = selection.get("decisions") or {}
+    if not isinstance(decisions, dict) or not decisions:
+        return "(none)"
+    keep_n = sum(1 for value in decisions.values() if value == "keep")
+    skip_n = sum(1 for value in decisions.values() if value == "skip")
+    return f"{keep_n} keep, {skip_n} skip"
+
+
+def _protein_tool_input(protein: Protein) -> dict[str, Any]:
+    """Build the tool ``protein`` object from a Protein instance.
+
+    Args:
+        protein: Input protein with ``remote_path`` set.
+
+    Returns:
+        ``file_path`` plus ``id`` when the protein is registered.
+
+    Raises:
+        ValueError: If ``remote_path`` is missing.
+    """
+    file_path = protein.remote_path
+    if not file_path or not str(file_path).strip():
+        raise ValueError("Protein remote_path is required; sync the protein first.")
+    payload: dict[str, Any] = {"file_path": str(file_path)}
+    if protein.id:
+        payload["id"] = str(protein.id)
+    return payload
 
 
 def _protein_from_prepared_data(
@@ -98,21 +237,95 @@ def _protein_from_prepared_data(
     )
 
 
-class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
-    """Prepare a protein structure via ``deeporigin.protein-prep`` (async-only).
+def selection_from_recommendation(
+    recommendation: dict[str, Any],
+    *,
+    resolve_review_as: str = "skip",
+) -> dict[str, Any]:
+    """Build a frozen Selection from a recommend ``jobOutputs`` payload.
 
-    Submit with :meth:`start`, track with :meth:`wait` / :meth:`watch` /
-    :meth:`sync`, then load an in-memory :class:`Protein` from
-    :meth:`get_results`. There is no ``run()``. Quoting is unused (billing is
-    skipped); do not pass ``quote=True``.
+    Each component's tri-state recommendation becomes a binary ``keep`` or
+    ``skip``. Items marked ``review`` are mapped with *resolve_review_as*
+    (default ``skip``).
+
+    Args:
+        recommendation: ``jobOutputs.recommendation`` dict (``source_sha256``,
+            ``analyzer_version``, ``components``).
+        resolve_review_as: Decision to apply to every ``review`` component.
+            Must be ``keep`` or ``skip``.
+
+    Returns:
+        Selection with ``source_sha256``, ``analyzer_version``, and
+        ``decisions``.
+
+    Raises:
+        ValueError: If the recommendation is missing required fields, a
+            component has no id, or *resolve_review_as* is invalid.
+    """
+    if resolve_review_as not in _VALID_DECISIONS:
+        raise ValueError(
+            f"resolve_review_as must be 'keep' or 'skip', got {resolve_review_as!r}."
+        )
+    source_sha256 = recommendation.get("source_sha256")
+    analyzer_version = recommendation.get("analyzer_version")
+    components = recommendation.get("components")
+    if not source_sha256 or not str(source_sha256).strip():
+        raise ValueError("recommendation must include source_sha256.")
+    if not analyzer_version or not str(analyzer_version).strip():
+        raise ValueError("recommendation must include analyzer_version.")
+    if not isinstance(components, list) or not components:
+        raise ValueError("recommendation must include a non-empty components list.")
+
+    decisions: dict[str, str] = {}
+    for index, raw in enumerate(components):
+        if not isinstance(raw, dict):
+            raise ValueError(f"recommendation.components[{index}] must be an object.")
+        component_id = raw.get("id")
+        if not component_id or not str(component_id).strip():
+            raise ValueError(f"recommendation.components[{index}] must include id.")
+        rec = str(raw.get("recommendation") or "")
+        if rec == "review":
+            rec = resolve_review_as
+        if rec not in _VALID_DECISIONS:
+            raise ValueError(
+                f"recommendation.components[{index}] recommendation must be "
+                f"keep, skip, or review, got {raw.get('recommendation')!r}."
+            )
+        decisions[str(component_id)] = rec
+    return {
+        "source_sha256": str(source_sha256),
+        "analyzer_version": str(analyzer_version),
+        "decisions": decisions,
+    }
+
+
+class ProteinPrep(
+    Execution,
+    SyncExecutableMixin,
+    AsyncExecutableMixin,
+    NotebookWatchMixin,
+):
+    """Prepare a protein via ``deeporigin.protein-prep``.
+
+    :meth:`start` is always valid. With no ``selection``, it runs
+    ``action=recommend``. After that job finishes, :meth:`as_prepare` (or
+    :meth:`from_recommendation`) builds a prepare run.
+
+    :meth:`run` is only valid for prepare with ``model_missing_loops=False``
+    (skips loop modelling). It blocks until the job finishes and returns an
+    in-memory :class:`Protein` via :meth:`get_results`. Recommend and
+    loops-on prepare must use :meth:`start`. Quoting is unused (billing is
+    skipped).
+
+    Displaying the object (``print(prep)`` or a notebook cell) lists every
+    input you can set and its current value.
 
     Attributes:
         protein: Input protein structure (unchanged after the run).
-        pdb_id: 4-character PDB ID used for loop-modelling templates.
-        keep_chain_ids: Chain IDs to keep; empty means all chains.
-        keep_cofactor_ids: Cofactor/metal residue names to keep; empty keeps none.
-        keep_water_residue_names: Water residue-name classes to keep; empty keeps none.
-        remove_ligand_ids: Ligand residue names to remove during cleanup.
+        action: ``recommend`` or ``prepare``.
+        pdb_id: 4-character PDB ID for loop-modelling templates (prepare).
+        selection: Frozen keep/skip map (prepare only).
+        model_missing_loops: When ``False``, prepare skips loop modelling.
     """
 
     tool_key: str = TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"]
@@ -122,79 +335,156 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
         self,
         protein: Protein,
         *,
+        action: ProteinPrepAction | None = None,
         pdb_id: str | None = None,
-        keep_chain_ids: list[str] | None = None,
-        keep_cofactor_ids: list[str] | None = None,
-        keep_water_residue_names: list[str] | None = None,
-        remove_ligand_ids: list[str] | None = None,
+        selection: dict[str, Any] | None = None,
+        model_missing_loops: bool = True,
         tool_version: str = TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
         client: DeepOriginClient | None = None,
     ) -> None:
         """Create a ProteinPrep for the given protein.
 
+        With no ``selection``, this is a recommend run. Pass ``selection``
+        (or use :meth:`as_prepare`) for prepare.
+
         Args:
-            protein: Protein structure to prepare.
+            protein: Protein structure to inventory or prepare.
+            action: ``recommend`` or ``prepare``. Inferred from whether
+                ``selection`` is set when omitted.
             pdb_id: 4-character PDB ID for loop modelling. Inferred from
-                ``protein.pdb_id`` when omitted.
-            keep_chain_ids: Chain IDs to keep. Empty (default) keeps all chains.
-            keep_cofactor_ids: Cofactor/metal residue names to keep. Empty
-                (default) keeps none.
-            keep_water_residue_names: Water residue-name classes to keep.
-                Empty (default) keeps none.
-            remove_ligand_ids: Ligand residue names to remove. Empty (default)
-                removes none beyond the tool's cleanup defaults.
+                ``protein.pdb_id`` when omitted. Required for prepare unless
+                ``model_missing_loops`` is ``False``. Stored on recommend runs
+                so :meth:`as_prepare` can reuse it.
+            selection: Digest-bound frozen Selection (``source_sha256``,
+                ``analyzer_version``, ``decisions``). Required for prepare.
+            model_missing_loops: When ``False``, skip loop modelling and do
+                not require ``pdb_id``. Ignored for recommend (must stay
+                ``True``).
             tool_version: Platform tool version pin.
             client: Optional API client. Uses the default if not provided.
 
         Raises:
-            ValueError: If ``pdb_id`` cannot be resolved or is not 4 alphanumeric
-                characters.
+            ValueError: If ``action``/``selection`` disagree, ``pdb_id`` is
+                missing for loops-on prepare, ``pdb_id`` is malformed, or
+                ``selection`` is invalid.
         """
         super().__init__(client=client)
         self.tool_version = tool_version
         self._protein = protein
-        self._pdb_id = _resolve_pdb_id(protein=protein, pdb_id=pdb_id)
-        self._keep_chain_ids = _copy_str_list(keep_chain_ids)
-        self._keep_cofactor_ids = _copy_str_list(keep_cofactor_ids)
-        self._keep_water_residue_names = _copy_str_list(keep_water_residue_names)
-        self._remove_ligand_ids = _copy_str_list(remove_ligand_ids)
+        resolved_action = _resolve_action(action=action, selection=selection)
+        if resolved_action == "recommend" and not model_missing_loops:
+            raise ValueError(
+                "model_missing_loops=False requires action='prepare' and a "
+                "selection. Run recommend first, then "
+                "as_prepare(model_missing_loops=False)."
+            )
+        self._action: ProteinPrepAction = resolved_action
+        self._pdb_id = _optional_pdb_id(protein=protein, pdb_id=pdb_id)
+        self._selection = _copy_selection(selection) if selection is not None else None
+        self._model_missing_loops = (
+            True if resolved_action == "recommend" else model_missing_loops
+        )
+        if (
+            resolved_action == "prepare"
+            and self._model_missing_loops
+            and not self._pdb_id
+        ):
+            raise ValueError(PROTEIN_PREP_PDB_ID_REQUIRED_MSG)
 
     @property
     def protein(self) -> Protein:
-        """Input protein structure used for preparation."""
+        """Input protein structure used for recommendation or preparation."""
         return self._protein
 
     @property
-    def pdb_id(self) -> str:
-        """4-character PDB ID used for loop-modelling templates."""
+    def action(self) -> str:
+        """``recommend`` or ``prepare``."""
+        return self._action
+
+    @property
+    def pdb_id(self) -> str | None:
+        """4-character PDB ID used for loop-modelling templates, if set."""
         return self._pdb_id
 
     @property
-    def keep_chain_ids(self) -> list[str]:
-        """Protein chain IDs to keep; empty means all chains."""
-        return self._keep_chain_ids
+    def selection(self) -> dict[str, Any] | None:
+        """Frozen Selection for prepare; ``None`` on a recommend run."""
+        return self._selection
 
     @property
-    def keep_cofactor_ids(self) -> list[str]:
-        """Cofactor/metal residue names to keep; empty keeps none."""
-        return self._keep_cofactor_ids
+    def model_missing_loops(self) -> bool:
+        """Whether prepare will run loop modelling (unused for recommend)."""
+        return self._model_missing_loops
 
-    @property
-    def keep_water_residue_names(self) -> list[str]:
-        """Water residue-name classes to keep; empty keeps none."""
-        return self._keep_water_residue_names
+    def _parameter_rows(self) -> list[tuple[str, str]]:
+        """Return ``(name, value)`` rows for text and HTML display.
 
-    @property
-    def remove_ligand_ids(self) -> list[str]:
-        """Ligand residue names to remove during cleanup."""
-        return self._remove_ligand_ids
+        Includes constructor parameters and, when set, execution ``name``,
+        ``id``, and ``status``.
+        """
+        rows: list[tuple[str, str]] = [
+            ("protein", _protein_display_value(self.protein)),
+            ("action", self.action),
+            ("pdb_id", self.pdb_id if self.pdb_id else "(none)"),
+            (
+                "model_missing_loops",
+                str(self.model_missing_loops),
+            ),
+            ("selection", _format_selection_display(self.selection)),
+            ("tool_version", str(self.tool_version)),
+        ]
+        if self.name:
+            rows.append(("name", self.name))
+        if self.id:
+            rows.append(("id", self.id))
+        status = getattr(self, "status", None)
+        if status:
+            rows.append(("status", str(status)))
+        return rows
 
     def __repr__(self) -> str:
-        """Return a concise summary of this ProteinPrep."""
-        parts = [f"ProteinPrep protein={self.protein.id!r} pdb_id={self.pdb_id!r}"]
-        if self.id:
-            parts.append(f"id={self.id!r}")
-        return f"<{' '.join(parts)}>"
+        """Return a table of controllable parameters and their values."""
+        from tabulate import tabulate
+
+        return "ProteinPrep\n" + tabulate(
+            self._parameter_rows(),
+            headers=["Parameter", "Value"],
+            tablefmt="rounded_grid",
+        )
+
+    __str__ = __repr__
+
+    def _repr_html_(self) -> str:
+        """Return an HTML table of parameters for Jupyter display.
+
+        Returns:
+            HTML fragment with a Parameter/Value table. Values are escaped.
+        """
+        header = (
+            "<tr>"
+            "<th style='text-align:left;padding:4px 16px 4px 0'>Parameter</th>"
+            "<th style='text-align:left;padding:4px 0'>Value</th>"
+            "</tr>"
+        )
+        body_parts: list[str] = []
+        for name, value in self._parameter_rows():
+            body_parts.append(
+                "<tr>"
+                "<td style='padding:4px 16px 4px 0;font-family:ui-monospace,"
+                "SFMono-Regular,Menlo,monospace;white-space:nowrap'>"
+                f"{escape(name, quote=False)}</td>"
+                "<td style='padding:4px 0;font-family:ui-monospace,"
+                "SFMono-Regular,Menlo,monospace'>"
+                f"{escape(value, quote=False)}</td>"
+                "</tr>"
+            )
+        return (
+            "<div>"
+            "<div style='font-weight:600;margin-bottom:4px'>ProteinPrep</div>"
+            "<table style='border-collapse:collapse'>"
+            f"<thead>{header}</thead><tbody>{''.join(body_parts)}</tbody>"
+            "</table></div>"
+        )
 
     def _ensure_protein_remote(self) -> None:
         """Upload/sync the protein and ensure ``remote_path`` is set."""
@@ -205,35 +495,43 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
         self,
         *,
         approve_amount: int | None,
-        sync: bool,  # noqa: ARG002
+        sync: bool,
     ) -> dict[str, Any]:
         """Build the POST body for ``executions.create``.
 
-        ``sync`` is unused: Protein Prep has no ``sync`` input and always runs
-        as an async workflow.
+        Top-level ``sync`` asks the platform to block on create (SystemPrep
+        style). It is not an input field: the protein-prep schema has no
+        ``sync`` property.
 
         Args:
             approve_amount: Spend cap; omitted from the body when ``None``.
-            sync: Ignored (kept for the Execution payload contract).
+            sync: ``True`` for :meth:`run` (blocking create); ``False`` for
+                :meth:`start`.
 
         Returns:
             Payload for ``client.executions.create``.
         """
-        protein = self._protein
+        inputs: dict[str, Any] = {
+            "action": self._action,
+            "protein": _protein_tool_input(self._protein),
+        }
+        if self._action == "prepare":
+            if self._selection is None:
+                raise ValueError("prepare requires a selection.")
+            inputs["selection"] = {
+                "source_sha256": self._selection["source_sha256"],
+                "analyzer_version": self._selection["analyzer_version"],
+                "decisions": dict(self._selection["decisions"]),
+            }
+            if not self._model_missing_loops:
+                inputs["model_missing_loops"] = False
+            if self._pdb_id:
+                inputs["pdb_id"] = self._pdb_id
         payload: dict[str, Any] = {
-            "inputs": {
-                "protein": {
-                    "id": protein.id,
-                    "file_path": protein.remote_path,
-                },
-                "pdb_id": self._pdb_id,
-                "keep_chain_ids": list(self._keep_chain_ids),
-                "keep_cofactor_ids": list(self._keep_cofactor_ids),
-                "keep_water_residue_names": list(self._keep_water_residue_names),
-                "remove_ligand_ids": list(self._remove_ligand_ids),
-            },
+            "inputs": inputs,
             "outputs": {},
             "metadata": {},
+            "sync": sync,
         }
         if approve_amount is not None:
             payload["approveAmount"] = approve_amount
@@ -256,49 +554,212 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
             raise ValueError("Execution response must contain 'executionId'") from None
         self.update_from_dto(execution_dto)
 
+    def _require_loops_off_prepare(self) -> None:
+        """Raise unless this instance may ``run()``.
+
+        ``run()`` is only legal for ``action='prepare'`` with
+        ``model_missing_loops=False``.
+
+        Raises:
+            ValueError: If this is a recommend run or loops-on prepare.
+        """
+        if self._action != "prepare" or self._model_missing_loops:
+            raise ValueError(PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG)
+
+    def run(
+        self,
+        *,
+        quote: bool = False,
+        approve_amount: int | None = None,
+    ) -> Protein | None:
+        """Execute loops-off prepare synchronously (blocking).
+
+        Only valid when :attr:`action` is ``prepare`` and
+        :attr:`model_missing_loops` is ``False``. Recommend and loops-on
+        prepare must use :meth:`start`.
+
+        Pass ``quote=True`` (or ``approve_amount=0``) to request a cost
+        estimate only. Billing is skipped for this tool, so quoting is
+        unused. If the platform returns a ``Quoted`` DTO, ``None`` is
+        returned.
+
+        Args:
+            quote: Shorthand for ``approve_amount=0``.
+            approve_amount: Spend cap forwarded to the platform as
+                ``approveAmount``.
+
+        Returns:
+            An in-memory :class:`Protein`, or ``None`` when the platform
+            responds with ``Quoted`` status.
+
+        Raises:
+            ValueError: If this is not loops-off prepare.
+            DeepOriginException: If no prepared PDB path could be loaded.
+        """
+        self._require_loops_off_prepare()
+        self._ensure_protein_remote()
+        resolved_amount = 0 if quote else approve_amount
+        dto = self._create_execution(
+            data=self._make_payload(approve_amount=resolved_amount, sync=True),
+        )
+        self.update_from_dto(dto)
+
+        if self.status == "Quoted":
+            return None
+
+        return self.get_results(dto)
+
     @staticmethod
-    def _parse_inputs_dict(
-        inputs: dict[str, Any],
-    ) -> tuple[dict[str, Any], str, list[str], list[str], list[str], list[str]]:
-        """Parse stored userInputs into protein dict, pdb_id, and keep/remove lists.
+    def selection_from_recommendation(
+        recommendation: dict[str, Any],
+        *,
+        resolve_review_as: str = "skip",
+    ) -> dict[str, Any]:
+        """Build a frozen Selection from a recommend result.
+
+        See :func:`selection_from_recommendation`.
+        """
+        return selection_from_recommendation(
+            recommendation,
+            resolve_review_as=resolve_review_as,
+        )
+
+    @classmethod
+    def from_recommendation(
+        cls,
+        protein: Protein,
+        recommendation: dict[str, Any],
+        *,
+        pdb_id: str | None = None,
+        model_missing_loops: bool = True,
+        resolve_review_as: str = "skip",
+        tool_version: str = TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
+        client: DeepOriginClient | None = None,
+    ) -> Self:
+        """Build a prepare ``ProteinPrep`` from a recommend payload.
+
+        Args:
+            protein: Same protein that was recommended (same structure bytes).
+            recommendation: ``jobOutputs.recommendation`` dict.
+            pdb_id: PDB ID for loop modelling. Inferred from
+                ``protein.pdb_id`` when omitted.
+            model_missing_loops: When ``False``, skip loop modelling.
+            resolve_review_as: Binary decision for every ``review`` component.
+            tool_version: Platform tool version pin.
+            client: Optional API client.
+
+        Returns:
+            A ``ProteinPrep`` with ``action='prepare'`` ready for ``start()``
+            or, when ``model_missing_loops=False``, ``run()``.
+        """
+        selection = selection_from_recommendation(
+            recommendation,
+            resolve_review_as=resolve_review_as,
+        )
+        return cls(
+            protein,
+            action="prepare",
+            pdb_id=pdb_id,
+            selection=selection,
+            model_missing_loops=model_missing_loops,
+            tool_version=tool_version,
+            client=client,
+        )
+
+    def as_prepare(
+        self,
+        *,
+        pdb_id: str | None = None,
+        model_missing_loops: bool = True,
+        resolve_review_as: str = "skip",
+    ) -> ProteinPrep:
+        """Return a prepare ``ProteinPrep`` from this completed recommend run.
+
+        Args:
+            pdb_id: PDB ID for loop modelling. Defaults to this instance's
+                ``pdb_id`` (constructor / ``protein.pdb_id``).
+            model_missing_loops: When ``False``, skip loop modelling.
+            resolve_review_as: Binary decision for every ``review`` component.
+
+        Returns:
+            A new ``ProteinPrep`` with ``action='prepare'``. Call ``run()``
+            when ``model_missing_loops=False``, or ``start()`` otherwise.
+
+        Raises:
+            ValueError: If this instance is not a recommend run, or no
+                recommendation is available yet.
+        """
+        if self._action != "recommend":
+            raise ValueError(
+                "as_prepare() requires a recommend run. Construct ProteinPrep "
+                "without selection and call start() first."
+            )
+        recommendation = self.get_recommendation()
+        resolved_pdb_id = pdb_id if pdb_id is not None else self._pdb_id
+        return type(self).from_recommendation(
+            self._protein,
+            recommendation,
+            pdb_id=resolved_pdb_id,
+            model_missing_loops=model_missing_loops,
+            resolve_review_as=resolve_review_as,
+            tool_version=self.tool_version,
+            client=self.client,
+        )
+
+    @staticmethod
+    def _parse_inputs_dict(inputs: dict[str, Any]) -> _ParsedInputs:
+        """Parse stored userInputs into protein, action, and prepare fields.
+
+        Accepts Protein Prep v2 (``action`` + optional ``selection``) and v1
+        (keep/remove lists, treated as prepare with no selection).
 
         Args:
             inputs: Execution ``userInputs`` (or ``inputs``) dict.
 
         Returns:
-            ``protein`` input dict, resolved ``pdb_id``, and the four keep/remove
-            lists.
+            Parsed protein dict, action, optional ``pdb_id``, optional
+            selection, and ``model_missing_loops``.
 
         Raises:
-            ValueError: If ``pdb_id`` is missing or invalid, or ``protein`` is
-                not an object.
+            ValueError: If ``protein`` is not an object, ``action`` is
+                unknown, or ``pdb_id`` / ``selection`` are invalid.
         """
         protein_input = inputs.get("protein") or {}
         if not isinstance(protein_input, dict):
             raise ValueError("Missing 'protein' object in execution userInputs.")
-        raw_pdb_id = inputs.get("pdb_id")
-        if raw_pdb_id is None or not str(raw_pdb_id).strip():
-            raise ValueError("Missing 'pdb_id' in execution userInputs.")
-        pdb_id = str(raw_pdb_id).strip()
-        if _PDB_ID_RE.fullmatch(pdb_id) is None:
+
+        raw_action = inputs.get("action")
+        if raw_action is None:
+            action: ProteinPrepAction = "prepare"
+        elif raw_action in _VALID_ACTIONS:
+            action = raw_action  # type: ignore[assignment]
+        else:
             raise ValueError(
-                "pdb_id from execution inputs must be a 4-character "
-                f"alphanumeric PDB identifier, got {pdb_id!r}."
+                f"Unknown ProteinPrep action {raw_action!r}; expected "
+                "'recommend' or 'prepare'."
             )
 
-        def _list_field(name: str) -> list[str]:
-            raw = inputs.get(name) or []
-            if not isinstance(raw, list):
-                raise ValueError(f"Invalid {name} in execution inputs.")
-            return [str(item) for item in raw]
+        raw_pdb_id = inputs.get("pdb_id")
+        pdb_id: str | None = None
+        if raw_pdb_id is not None and str(raw_pdb_id).strip():
+            pdb_id = _normalize_pdb_id(str(raw_pdb_id))
 
-        return (
-            protein_input,
-            pdb_id,
-            _list_field("keep_chain_ids"),
-            _list_field("keep_cofactor_ids"),
-            _list_field("keep_water_residue_names"),
-            _list_field("remove_ligand_ids"),
+        raw_selection = inputs.get("selection")
+        selection: dict[str, Any] | None = None
+        if raw_selection is not None:
+            if not isinstance(raw_selection, dict):
+                raise ValueError("Invalid selection in execution inputs.")
+            selection = _copy_selection(raw_selection)
+
+        raw_loops = inputs.get("model_missing_loops")
+        model_missing_loops = True if raw_loops is None else bool(raw_loops)
+
+        return _ParsedInputs(
+            protein=protein_input,
+            action=action,
+            pdb_id=pdb_id,
+            selection=selection,
+            model_missing_loops=model_missing_loops,
         )
 
     @classmethod
@@ -310,32 +771,28 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
     ) -> Self:
         """Construct a ``ProteinPrep`` from a tools execution DTO.
 
-        Rehydrates ``protein``, ``pdb_id``, and keep/remove lists from
-        ``userInputs`` (falling back to ``inputs``).
+        Rehydrates ``protein``, ``action``, ``pdb_id``, ``selection``, and
+        ``model_missing_loops`` from ``userInputs`` (falling back to
+        ``inputs``).
 
         Args:
             dto: Execution payload (same shape as ``client.executions.get``).
             client: Optional API client. Uses the default if not provided.
 
         Returns:
-            A ``ProteinPrep`` with ``id``, lifecycle fields, and domain inputs set.
+            A ``ProteinPrep`` with ``id``, lifecycle fields, and domain inputs
+            set.
 
         Raises:
-            ValueError: If ``pdb_id`` is missing from stored inputs.
+            ValueError: If stored inputs are missing ``protein`` or use an
+                unknown ``action``.
         """
         instance = super().from_dto(dto, client=client)
         inputs: dict[str, Any] = dto.get("userInputs") or dto.get("inputs") or {}
-        (
-            protein_input,
-            pdb_id,
-            keep_chain_ids,
-            keep_cofactor_ids,
-            keep_water_residue_names,
-            remove_ligand_ids,
-        ) = cls._parse_inputs_dict(inputs)
+        parsed = cls._parse_inputs_dict(inputs)
 
-        protein_id = protein_input.get("id")
-        file_path = protein_input.get("file_path")
+        protein_id = parsed.protein.get("id")
+        file_path = parsed.protein.get("file_path")
         if protein_id is not None:
             instance._protein = Protein.from_id(
                 str(protein_id),
@@ -344,17 +801,22 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
                 remote_path_override=file_path,
             )
         else:
+            if parsed.pdb_id:
+                name = parsed.pdb_id
+            elif file_path:
+                name = str(file_path).rsplit("/", 1)[-1]
+            else:
+                name = "protein"
             instance._protein = Protein(
-                name=str(pdb_id),
-                pdb_id=pdb_id,
+                name=name,
+                pdb_id=parsed.pdb_id,
                 structure=None,
                 remote_path=file_path,
             )
-        instance._pdb_id = pdb_id
-        instance._keep_chain_ids = keep_chain_ids
-        instance._keep_cofactor_ids = keep_cofactor_ids
-        instance._keep_water_residue_names = keep_water_residue_names
-        instance._remove_ligand_ids = remove_ligand_ids
+        instance._action = parsed.action
+        instance._pdb_id = parsed.pdb_id
+        instance._selection = parsed.selection
+        instance._model_missing_loops = parsed.model_missing_loops
         return instance
 
     def _protein_from_outputs(self, data: dict[str, Any]) -> Protein:
@@ -371,6 +833,54 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
             data,
             fallback_pdb_id=self._pdb_id,
             fallback_name=self._protein.name,
+        )
+
+    def _recommendation_from_dto(
+        self,
+        dto: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Return ``jobOutputs.recommendation`` from *dto* when present."""
+        if not isinstance(dto, dict):
+            return None
+        job_outputs = dto.get("jobOutputs")
+        if not isinstance(job_outputs, dict):
+            return None
+        recommendation = job_outputs.get("recommendation")
+        if isinstance(recommendation, dict) and recommendation.get("components"):
+            return recommendation
+        return None
+
+    @beartype
+    def get_recommendation(self, dto: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Load the component inventory from a recommend run.
+
+        Args:
+            dto: Optional execution payload. Passing it avoids an extra GET
+                when ``jobOutputs.recommendation`` is already in hand.
+
+        Returns:
+            The ``recommendation`` object (``source_sha256``,
+            ``analyzer_version``, ``components``, ``chain_id_mapping``).
+
+        Raises:
+            ValueError: If :attr:`id` is unset.
+            DeepOriginException: If no recommendation could be loaded.
+        """
+        exec_id = self._ensure_id()
+        for candidate in (dto, self._dto):
+            recommendation = self._recommendation_from_dto(candidate)
+            if recommendation is not None:
+                return recommendation
+        try:
+            exec_dto = self.client.executions.get(exec_id)  # ty:ignore[unresolved-attribute]
+        except Exception:
+            exec_dto = None
+        recommendation = self._recommendation_from_dto(exec_dto)
+        if recommendation is not None:
+            return recommendation
+        raise DeepOriginException(
+            title="Could not load protein recommendation",
+            message=PROTEIN_PREP_NO_RECOMMENDATION_MSG,
         )
 
     @beartype
@@ -392,9 +902,15 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
 
         Raises:
             ValueError: If :attr:`id` is unset.
-            DeepOriginException: If no prepared PDB path could be loaded.
+            DeepOriginException: If this was a recommend run, or no prepared
+                PDB path could be loaded.
         """
         exec_id = self._ensure_id()
+        if self._action == "recommend":
+            raise DeepOriginException(
+                title="Could not load prepared protein",
+                message=PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,
+            )
 
         try:
             response = self.client.results.get(
@@ -425,3 +941,37 @@ class ProteinPrep(Execution, AsyncExecutableMixin, NotebookWatchMixin):
             title="Could not load prepared protein",
             message=PROTEIN_PREP_NO_OUTPUT_PATHS_MSG,
         )
+
+
+def _resolve_action(
+    *,
+    action: str | None,
+    selection: dict[str, Any] | None,
+) -> ProteinPrepAction:
+    """Infer or validate ``recommend`` vs ``prepare``.
+
+    Args:
+        action: Explicit action, or ``None`` to infer from *selection*.
+        selection: Frozen Selection, or ``None`` for recommend.
+
+    Returns:
+        ``recommend`` or ``prepare``.
+
+    Raises:
+        ValueError: If *action* is unknown, or *action* and *selection*
+            disagree.
+    """
+    if action is not None and action not in _VALID_ACTIONS:
+        raise ValueError(f"action must be 'recommend' or 'prepare', got {action!r}.")
+    if action == "recommend":
+        if selection is not None:
+            raise ValueError("action='recommend' does not accept a selection.")
+        return "recommend"
+    if action == "prepare":
+        if selection is None:
+            raise ValueError(
+                "action='prepare' requires a selection. Run recommend first, "
+                "or pass selection= from selection_from_recommendation()."
+            )
+        return "prepare"
+    return "prepare" if selection is not None else "recommend"

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -141,6 +141,45 @@ PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG = (
 )
 """Used by ``ProteinPrep.run`` when loop modelling is enabled."""
 
+PROTEIN_PREP_COMPONENT_KINDS: frozenset[str] = frozenset(
+    {"chain", "ligand", "cofactor", "water"}
+)
+"""Valid Protein Prep Component ``kind`` values for table filters and keep/skip."""
+
+PROTEIN_PREP_RECOMMENDATION_COLUMNS: tuple[str, ...] = (
+    "id",
+    "kind",
+    "subtype",
+    "label",
+    "recommendation",
+    "decision",
+    "reason",
+    "evidence",
+)
+"""Column order for the Protein Prep Recommendation view DataFrame."""
+
+PROTEIN_PREP_KEEP_SKIP_EMPTY_MSG = (
+    "{method}() requires component IDs or keyword filters."
+)
+"""Used when ``keep()`` / ``skip()`` are called with no ids and no matchers."""
+
+PROTEIN_PREP_KEEP_SKIP_MIXED_MSG = "Pass component IDs or keyword filters, not both."
+"""Used when ``keep()`` / ``skip()`` receive both positional ids and matchers."""
+
+PROTEIN_PREP_KEEP_SKIP_VIEW_MSG = (
+    "{method}() accepts a DataFrame from recommendation(...), "
+    "not the recommendation view itself."
+)
+"""Used when ``keep()`` / ``skip()`` are passed the uncalled Recommendation view."""
+
+PROTEIN_PREP_DATAFRAME_ID_COLUMN_MSG = "DataFrame must include an 'id' column."
+"""Used when ``keep()`` / ``skip()`` receive a DataFrame without ``id``."""
+
+PROTEIN_PREP_SUBTYPE_REQUIRES_RECOMMENDATION_MSG = (
+    "subtype= requires a recommendation. Call recommend() first."
+)
+"""Used when ``keep()`` / ``skip()`` filter by subtype without analyzer evidence."""
+
 BOOTSTRAP_5_CSS_CDN_URL = (
     "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
 )

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -113,6 +113,34 @@ PROTEIN_PREP_NO_OUTPUT_PATHS_MSG = (
 )
 """Used by ``ProteinPrep.get_results`` when the prepared PDB path is missing."""
 
+PROTEIN_PREP_PDB_ID_REQUIRED_MSG = (
+    "pdb_id is required when preparing with loop modelling. "
+    "Pass pdb_id= as a 4-character PDB identifier, or set protein.pdb_id. "
+    "To skip loop modelling, pass model_missing_loops=False."
+)
+"""Used by ``ProteinPrep`` when prepare + loops-on is missing ``pdb_id``."""
+
+PROTEIN_PREP_NO_RECOMMENDATION_MSG = (
+    "Protein Prep did not return a recommendation. "
+    "This execution may have used action='prepare', failed, or returned an "
+    "unexpected format."
+)
+"""Used by ``ProteinPrep.get_recommendation`` when the inventory is missing."""
+
+PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG = (
+    "This ProteinPrep ran action='recommend' and did not produce a prepared "
+    "protein. Call get_recommendation(), then as_prepare() (or "
+    "ProteinPrep.from_recommendation) to submit a prepare run."
+)
+"""Used by ``ProteinPrep.get_results`` on a recommend execution."""
+
+PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG = (
+    "run() is only valid for prepare with model_missing_loops=False. "
+    "Use start() for recommend or for prepare with loop modelling, or call "
+    "as_prepare(model_missing_loops=False) first."
+)
+"""Used by ``ProteinPrep.run`` when the instance is not loops-off prepare."""
+
 BOOTSTRAP_5_CSS_CDN_URL = (
     "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
 )

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -107,6 +107,9 @@ SYSPREP_NO_OUTPUT_PATHS_MSG = (
 PROTEIN_PREP_PDB_ID_PATTERN = r"^[A-Za-z0-9]{4}$"
 """JSON Schema pattern for Protein Prep ``pdb_id`` (loop-modelling templates)."""
 
+PROTEIN_PREP_DISPLAY_NONE = "(none)"
+"""Display value for unavailable Protein Prep configuration."""
+
 PROTEIN_PREP_NO_OUTPUT_PATHS_MSG = (
     "Protein preparation did not return a prepared PDB path. "
     "The tool execution may have failed or returned an unexpected format."
@@ -122,24 +125,21 @@ PROTEIN_PREP_PDB_ID_REQUIRED_MSG = (
 
 PROTEIN_PREP_NO_RECOMMENDATION_MSG = (
     "Protein Prep did not return a recommendation. "
-    "This execution may have used action='prepare', failed, or returned an "
-    "unexpected format."
+    "The recommendation operation may have failed or returned an unexpected format."
 )
-"""Used by ``ProteinPrep.get_recommendation`` when the inventory is missing."""
+"""Used by ``ProteinPrep.recommend`` when the inventory is missing."""
 
 PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG = (
-    "This ProteinPrep ran action='recommend' and did not produce a prepared "
-    "protein. Call get_recommendation(), then as_prepare() (or "
-    "ProteinPrep.from_recommendation) to submit a prepare run."
+    "This historical ProteinPrep execution contains a recommendation and did "
+    "not produce a prepared protein. Inspect the recommendation property."
 )
 """Used by ``ProteinPrep.get_results`` on a recommend execution."""
 
 PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG = (
-    "run() is only valid for prepare with model_missing_loops=False. "
-    "Use start() for recommend or for prepare with loop modelling, or call "
-    "as_prepare(model_missing_loops=False) first."
+    "run() requires model_missing_loops=False. Use start() when loop modelling "
+    "is enabled."
 )
-"""Used by ``ProteinPrep.run`` when the instance is not loops-off prepare."""
+"""Used by ``ProteinPrep.run`` when loop modelling is enabled."""
 
 BOOTSTRAP_5_CSS_CDN_URL = (
     "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"

--- a/tests/fixtures/executions/protein-prep-recommend-execution.json
+++ b/tests/fixtures/executions/protein-prep-recommend-execution.json
@@ -1,0 +1,74 @@
+{
+    "app": "python-client",
+    "approveAmount": null,
+    "billing": null,
+    "cluster": {
+        "id": "d638d3cd-833f-476b-87fe-ca6d76e66049"
+    },
+    "completedAt": "2026-08-14T12:00:00.000Z",
+    "createdAt": "2026-08-14T11:59:00.000Z",
+    "createdBy": "6b96d8f8-0f55-474c-a86c-e09651ba4b20",
+    "executionId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "executionType": "tool",
+    "metadata": {},
+    "name": "ProteinPrep recommend on brd",
+    "orgKey": "deeporigin",
+    "progressReport": {
+        "complete": 100
+    },
+    "projectId": null,
+    "quotationResult": null,
+    "resourceId": "proteinpreptest002",
+    "session": "f8a98c5e-18ed-4b5e-b08a-f38a21d11254",
+    "startedAt": "2026-08-14T11:59:10.000Z",
+    "status": "Completed",
+    "statusReason": null,
+    "tag": null,
+    "tool": {
+        "key": "deeporigin.protein-prep",
+        "version": "2.0.8"
+    },
+    "type": "ToolExecution",
+    "updatedAt": "2026-08-14T12:00:00.000Z",
+    "userInputs": {
+        "action": "recommend",
+        "protein": {
+            "file_path": "testing/brd.pdb",
+            "id": "brd"
+        }
+    },
+    "userOutputs": {},
+    "jobOutputs": {
+        "recommendation": {
+            "analyzer_version": "1.0.0",
+            "chain_id_mapping": {},
+            "components": [
+                {
+                    "author": { "chain_id": "A" },
+                    "id": "chain:A",
+                    "kind": "chain",
+                    "label": "Chain A",
+                    "reason": "Ordinary protein chain",
+                    "reason_code": "ordinary_protein_chain",
+                    "recommendation": "keep",
+                    "subtype": "protein"
+                },
+                {
+                    "author": {
+                        "chain_id": "A",
+                        "resname": "LIG",
+                        "resseq": 100
+                    },
+                    "id": "ligand:LIG:A:100",
+                    "kind": "ligand",
+                    "label": "LIG",
+                    "reason": "Ambiguous ligand",
+                    "reason_code": "ambiguous_ligand",
+                    "recommendation": "review",
+                    "subtype": "small_molecule"
+                }
+            ],
+            "source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+    }
+}

--- a/tests/fixtures/executions/protein-prep-test-execution.json
+++ b/tests/fixtures/executions/protein-prep-test-execution.json
@@ -26,20 +26,25 @@
     "tag": null,
     "tool": {
         "key": "deeporigin.protein-prep",
-        "version": "0.1.0"
+        "version": "2.0.8"
     },
     "type": "ToolExecution",
     "updatedAt": "2026-08-14T12:00:00.000Z",
     "userInputs": {
-        "keep_chain_ids": ["A"],
-        "keep_cofactor_ids": ["MG"],
-        "keep_water_residue_names": ["HOH"],
+        "action": "prepare",
         "pdb_id": "1EBY",
         "protein": {
             "file_path": "testing/brd.pdb",
             "id": "brd"
         },
-        "remove_ligand_ids": ["LIG"]
+        "selection": {
+            "analyzer_version": "1.0.0",
+            "decisions": {
+                "chain:A": "keep",
+                "ligand:LIG:A:100": "skip"
+            },
+            "source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
     },
     "userOutputs": {},
     "jobOutputs": {

--- a/tests/fixtures/tool-runs/deeporigin.protein-prep/recommend.json
+++ b/tests/fixtures/tool-runs/deeporigin.protein-prep/recommend.json
@@ -1,0 +1,35 @@
+{
+  "jobOutputs": {
+    "recommendation": {
+      "analyzer_version": "1.0.0",
+      "chain_id_mapping": {},
+      "components": [
+        {
+          "author": { "chain_id": "A" },
+          "id": "chain:A",
+          "kind": "chain",
+          "label": "Chain A",
+          "reason": "Ordinary protein chain",
+          "reason_code": "ordinary_protein_chain",
+          "recommendation": "keep",
+          "subtype": "protein"
+        },
+        {
+          "author": {
+            "chain_id": "A",
+            "resname": "LIG",
+            "resseq": 100
+          },
+          "id": "ligand:LIG:A:100",
+          "kind": "ligand",
+          "label": "LIG",
+          "reason": "Ambiguous ligand",
+          "reason_code": "ambiguous_ligand",
+          "recommendation": "review",
+          "subtype": "small_molecule"
+        }
+      ],
+      "source_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  }
+}

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -1668,12 +1668,18 @@ def create_tools_router(
         if any(r.get("compute_job_id") == eid for r in results):
             return
 
-        fixture = copy.deepcopy(load_fixture("tool-runs/deeporigin.protein-prep/run"))
+        user_inputs = execution.get("userInputs", {})
+        action = user_inputs.get("action") if isinstance(user_inputs, dict) else None
+        fixture_name = (
+            "tool-runs/deeporigin.protein-prep/recommend"
+            if action == "recommend"
+            else "tool-runs/deeporigin.protein-prep/run"
+        )
+        fixture = copy.deepcopy(load_fixture(fixture_name))
         outputs = _legacy_outputs_to_job_outputs(fixture)
         if not isinstance(outputs, dict):
             return
 
-        user_inputs = execution.get("userInputs", {})
         protein = (
             user_inputs.get("protein", {}) if isinstance(user_inputs, dict) else {}
         )

--- a/tests/test_protein_prep.py
+++ b/tests/test_protein_prep.py
@@ -8,23 +8,94 @@ from pathlib import Path
 import pytest
 
 from deeporigin.drug_discovery import Protein, ProteinPrep
+from deeporigin.drug_discovery.protein_prep import selection_from_recommendation
+from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
+from deeporigin.utils.constants import (
+    PROTEIN_PREP_PDB_ID_REQUIRED_MSG,
+    PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,
+    PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG,
+)
 from tests.conftest import check_tool_exists
+
+_SHA256 = "a" * 64
+_SAMPLE_SELECTION = {
+    "analyzer_version": "1.0.0",
+    "decisions": {"chain:A": "keep", "ligand:LIG:A:100": "skip"},
+    "source_sha256": _SHA256,
+}
+_SAMPLE_RECOMMENDATION = {
+    "analyzer_version": "1.0.0",
+    "chain_id_mapping": {},
+    "components": [
+        {
+            "author": {"chain_id": "A"},
+            "id": "chain:A",
+            "kind": "chain",
+            "label": "Chain A",
+            "reason": "Ordinary protein chain",
+            "reason_code": "ordinary_protein_chain",
+            "recommendation": "keep",
+            "subtype": "protein",
+        },
+        {
+            "author": {"chain_id": "A", "resname": "LIG", "resseq": 100},
+            "id": "ligand:LIG:A:100",
+            "kind": "ligand",
+            "label": "LIG",
+            "reason": "Ambiguous ligand",
+            "reason_code": "ambiguous_ligand",
+            "recommendation": "review",
+            "subtype": "small_molecule",
+        },
+    ],
+    "source_sha256": _SHA256,
+}
+
+
+def _protein_with_remote(*, pdb_id: str | None = "1EBY") -> Protein:
+    """In-memory protein with a remote path so payload tests skip upload."""
+    protein = Protein(name="test", pdb_id=pdb_id)
+    protein.remote_path = "testing/brd.pdb"
+    return protein
+
+
+def test_protein_prep_defaults_to_recommend() -> None:
+    """Constructor without selection is a recommend run; pdb_id is optional."""
+    protein = Protein(name="test")
+    prep = ProteinPrep(protein)
+    assert prep.action == "recommend"
+    assert prep.pdb_id is None
+    assert prep.selection is None
+    assert prep.model_missing_loops is True
 
 
 def test_protein_prep_infers_pdb_id_from_protein() -> None:
-    """Constructor uses protein.pdb_id when pdb_id= is omitted."""
+    """Constructor stores protein.pdb_id for later prepare."""
     protein = Protein(name="test", pdb_id="1EBY")
     prep = ProteinPrep(protein)
     assert prep.pdb_id == "1EBY"
 
 
-def test_protein_prep_requires_pdb_id_when_protein_has_none() -> None:
-    """Constructor raises when neither kwarg nor protein.pdb_id is set."""
+def test_protein_prep_prepare_requires_pdb_id_when_loops_on() -> None:
+    """Prepare with loop modelling raises when neither source has pdb_id."""
     protein = Protein(name="test")
     with pytest.raises(ValueError, match="pdb_id is required"):
-        ProteinPrep(protein)
+        ProteinPrep(protein, selection=_SAMPLE_SELECTION)
+
+
+def test_protein_prep_prepare_loops_off_allows_missing_pdb_id() -> None:
+    """Prepare with model_missing_loops=False does not require pdb_id."""
+    protein = Protein(name="test")
+    prep = ProteinPrep(
+        protein,
+        selection=_SAMPLE_SELECTION,
+        model_missing_loops=False,
+    )
+    assert prep.action == "prepare"
+    assert prep.pdb_id is None
+    assert prep.model_missing_loops is False
 
 
 def test_protein_prep_rejects_invalid_pdb_id() -> None:
@@ -45,17 +116,168 @@ def test_protein_prep_explicit_pdb_id_overrides_protein() -> None:
     assert prep.pdb_id == "2XYZ"
 
 
-def test_protein_prep_keep_remove_defaults_are_empty() -> None:
-    """Keep/remove lists default to empty copies, not shared mutables."""
+def test_protein_prep_recommend_rejects_loops_off() -> None:
+    """model_missing_loops=False is invalid on a recommend run."""
+    protein = Protein(name="test")
+    with pytest.raises(ValueError, match="model_missing_loops=False"):
+        ProteinPrep(protein, model_missing_loops=False)
+
+
+def test_protein_prep_prepare_requires_selection() -> None:
+    """Explicit action='prepare' without selection raises."""
     protein = Protein(name="test", pdb_id="1EBY")
+    with pytest.raises(ValueError, match="requires a selection"):
+        ProteinPrep(protein, action="prepare")
+
+
+def test_protein_prep_recommend_rejects_selection() -> None:
+    """Explicit action='recommend' with selection raises."""
+    protein = Protein(name="test")
+    with pytest.raises(ValueError, match="does not accept a selection"):
+        ProteinPrep(protein, action="recommend", selection=_SAMPLE_SELECTION)
+
+
+def test_protein_prep_selection_copy_is_independent() -> None:
+    """Constructor copies selection so later mutations do not leak."""
+    protein = Protein(name="test", pdb_id="1EBY")
+    selection = {
+        "analyzer_version": "1.0.0",
+        "decisions": {"chain:A": "keep"},
+        "source_sha256": _SHA256,
+    }
+    prep = ProteinPrep(protein, selection=selection)
+    selection["decisions"]["chain:A"] = "skip"
+    assert prep.selection is not None
+    assert prep.selection["decisions"]["chain:A"] == "keep"
+
+
+def test_selection_from_recommendation_resolves_review_to_skip() -> None:
+    """Reviews become skip by default; keep/skip pass through."""
+    selection = selection_from_recommendation(_SAMPLE_RECOMMENDATION)
+    assert selection["source_sha256"] == _SHA256
+    assert selection["analyzer_version"] == "1.0.0"
+    assert selection["decisions"] == {
+        "chain:A": "keep",
+        "ligand:LIG:A:100": "skip",
+    }
+
+
+def test_selection_from_recommendation_can_keep_reviews() -> None:
+    """resolve_review_as='keep' maps review components to keep."""
+    selection = selection_from_recommendation(
+        _SAMPLE_RECOMMENDATION,
+        resolve_review_as="keep",
+    )
+    assert selection["decisions"]["ligand:LIG:A:100"] == "keep"
+
+
+def test_protein_prep_from_recommendation_builds_prepare() -> None:
+    """from_recommendation produces a prepare instance with a selection."""
+    protein = Protein(name="test", pdb_id="1EBY")
+    prep = ProteinPrep.from_recommendation(protein, _SAMPLE_RECOMMENDATION)
+    assert prep.action == "prepare"
+    assert prep.pdb_id == "1EBY"
+    assert prep.selection == _SAMPLE_SELECTION
+
+
+def test_protein_prep_repr_lists_parameters() -> None:
+    """repr/str show constructor parameters including action."""
+    protein = Protein(name="brd", pdb_id="1EBY")
     prep = ProteinPrep(protein)
-    assert prep.keep_chain_ids == []
-    assert prep.keep_cofactor_ids == []
-    assert prep.keep_water_residue_names == []
-    assert prep.remove_ligand_ids == []
-    prep.keep_chain_ids.append("A")
-    other = ProteinPrep(protein)
-    assert other.keep_chain_ids == []
+    text = repr(prep)
+
+    assert text == str(prep)
+    assert text.startswith("ProteinPrep")
+    assert "action" in text
+    assert "recommend" in text
+    assert "pdb_id" in text
+    assert "1EBY" in text
+    assert "selection" in text
+    assert "(none)" in text
+    assert "model_missing_loops" in text
+    assert "tool_version" in text
+    assert "brd" in text
+    names = [name for name, _ in prep._parameter_rows()]
+    assert "id" not in names
+    assert "status" not in names
+
+
+def test_protein_prep_repr_shows_selection_and_execution_fields() -> None:
+    """repr shows selection counts and id/status when set."""
+    protein = Protein(name="brd", id="prot-1", pdb_id="1EBY")
+    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION)
+    text = repr(prep)
+    assert "prepare" in text
+    assert "1 keep, 1 skip" in text
+    assert "id='prot-1'" in text
+
+    prep._id = "exec-abc"
+    prep.status = "Succeeded"
+    prep._name = "my-prep"
+    later = repr(prep)
+    assert "exec-abc" in later
+    assert "Succeeded" in later
+    assert "my-prep" in later
+
+
+def test_protein_prep_repr_html_escapes_and_lists_parameters() -> None:
+    """_repr_html_ is an HTML table of parameters with escaped values."""
+    protein = Protein(name="<script>", pdb_id="1EBY")
+    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION)
+    html = prep._repr_html_()
+
+    assert "<table" in html
+    assert "selection" in html
+    assert "pdb_id" in html
+    assert "1 keep, 1 skip" in html
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_protein_prep_recommend_payload_omits_v1_fields() -> None:
+    """Recommend POST body is action + protein only."""
+    protein = _protein_with_remote()
+    protein.id = "prot-1"
+    prep = ProteinPrep(protein, pdb_id="1EBY")
+    payload = prep._make_payload(approve_amount=None, sync=False)
+    assert payload["inputs"] == {
+        "action": "recommend",
+        "protein": {"file_path": "testing/brd.pdb", "id": "prot-1"},
+    }
+    assert payload["sync"] is False
+    assert "approveAmount" not in payload
+
+
+def test_protein_prep_prepare_payload_includes_selection() -> None:
+    """Prepare POST body includes action, protein, pdb_id, and selection."""
+    protein = _protein_with_remote()
+    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION, pdb_id="1EBY")
+    payload = prep._make_payload(approve_amount=None, sync=False)
+    inputs = payload["inputs"]
+    assert payload["sync"] is False
+    assert inputs["action"] == "prepare"
+    assert inputs["pdb_id"] == "1EBY"
+    assert inputs["selection"] == _SAMPLE_SELECTION
+    assert inputs["protein"]["file_path"] == "testing/brd.pdb"
+    assert "model_missing_loops" not in inputs
+    assert "keep_chain_ids" not in inputs
+
+
+def test_protein_prep_prepare_loops_off_payload() -> None:
+    """Loops-off prepare sends model_missing_loops=false and omits pdb_id."""
+    protein = _protein_with_remote(pdb_id=None)
+    prep = ProteinPrep(
+        protein,
+        selection=_SAMPLE_SELECTION,
+        model_missing_loops=False,
+    )
+    payload = prep._make_payload(approve_amount=None, sync=True)
+    inputs = payload["inputs"]
+    assert payload["sync"] is True
+    assert inputs["action"] == "prepare"
+    assert inputs["model_missing_loops"] is False
+    assert "pdb_id" not in inputs
+    assert "sync" not in inputs
 
 
 def test_protein_prep_start_rejects_non_none_status(
@@ -78,8 +300,8 @@ def test_protein_prep_get_results_requires_id() -> None:
         prep.get_results()
 
 
-def test_protein_prep_from_dto_maps_fields(client: DeepOriginClient) -> None:
-    """from_dto rehydrates protein, pdb_id, and keep/remove lists."""
+def test_protein_prep_from_dto_maps_prepare_fields(client: DeepOriginClient) -> None:
+    """from_dto rehydrates protein, action, pdb_id, and selection."""
     fixture_path = (
         Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
     )
@@ -89,12 +311,51 @@ def test_protein_prep_from_dto_maps_fields(client: DeepOriginClient) -> None:
 
     assert prep.id == dto["executionId"]
     assert prep.status == dto["status"]
+    assert prep.action == "prepare"
     assert prep.pdb_id == "1EBY"
-    assert prep.keep_chain_ids == ["A"]
-    assert prep.keep_cofactor_ids == ["MG"]
-    assert prep.keep_water_residue_names == ["HOH"]
-    assert prep.remove_ligand_ids == ["LIG"]
+    assert prep.selection == _SAMPLE_SELECTION
     assert prep.protein.remote_path == "testing/brd.pdb"
+
+
+def test_protein_prep_from_dto_maps_recommend_fields(client: DeepOriginClient) -> None:
+    """from_dto rehydrates a recommend execution without a selection."""
+    fixture_path = (
+        Path(__file__).parent
+        / "fixtures/executions/protein-prep-recommend-execution.json"
+    )
+    dto = json.loads(fixture_path.read_text())
+
+    prep = ProteinPrep.from_dto(dto, client=client)
+
+    assert prep.action == "recommend"
+    assert prep.selection is None
+    rec = prep.get_recommendation(dto)
+    assert rec["source_sha256"] == _SHA256
+    assert rec["components"][0]["id"] == "chain:A"
+
+
+def test_protein_prep_from_dto_v1_keep_lists_still_get_results(
+    client: DeepOriginClient,
+) -> None:
+    """v1 userInputs (no action) rehydrate as prepare so get_results still works."""
+    fixture_path = (
+        Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
+    )
+    dto = json.loads(fixture_path.read_text())
+    dto["userInputs"] = {
+        "keep_chain_ids": ["A"],
+        "keep_cofactor_ids": ["MG"],
+        "keep_water_residue_names": ["HOH"],
+        "pdb_id": "1EBY",
+        "protein": {"file_path": "testing/brd.pdb", "id": "brd"},
+        "remove_ligand_ids": ["LIG"],
+    }
+    prep = ProteinPrep.from_dto(dto, client=client)
+    assert prep.action == "prepare"
+    assert prep.selection is None
+    prepared = prep.get_results(dto)
+    assert isinstance(prepared, Protein)
+    assert prepared.remote_path == "testing/brd.pdb"
 
 
 def test_protein_prep_from_dto_initializes_notebook_watch_state(
@@ -127,26 +388,18 @@ def test_protein_prep_from_dto_rejects_tool_key_mismatch(
         ProteinPrep.from_dto(dto, client=client)
 
 
-def test_protein_prep_start_submits_payload(
+def test_protein_prep_start_submits_recommend_payload(
     client: DeepOriginClient,
     registered_protein: Protein,
 ) -> None:
-    """start() submits inputs without approveAmount and stores id/status."""
+    """start() without selection submits action=recommend and stores id/status."""
     assert check_tool_exists(
         client,
         TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
         TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
     ), "Protein prep tool not registered on platform (expected key/version)."
 
-    prep = ProteinPrep(
-        registered_protein,
-        pdb_id="1EBY",
-        keep_chain_ids=["A"],
-        keep_cofactor_ids=["ZN"],
-        keep_water_residue_names=["HOH"],
-        remove_ligand_ids=["LIG"],
-        client=client,
-    )
+    prep = ProteinPrep(registered_protein, pdb_id="1EBY", client=client)
     prep.start()
 
     assert prep.id is not None
@@ -157,22 +410,42 @@ def test_protein_prep_start_submits_payload(
         == TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"]
     )
     user_inputs = dto.get("userInputs") or {}
-    assert user_inputs.get("pdb_id") == "1EBY"
-    assert user_inputs.get("keep_chain_ids") == ["A"]
-    assert user_inputs.get("keep_cofactor_ids") == ["ZN"]
-    assert user_inputs.get("keep_water_residue_names") == ["HOH"]
-    assert user_inputs.get("remove_ligand_ids") == ["LIG"]
+    assert user_inputs.get("action") == "recommend"
+    assert "pdb_id" not in user_inputs
+    assert "keep_chain_ids" not in user_inputs
+    assert "selection" not in user_inputs
     protein_input = user_inputs.get("protein") or {}
     assert protein_input.get("id") == registered_protein.id
     assert protein_input.get("file_path") == registered_protein.remote_path
-    assert "approveAmount" not in (prep._make_payload(approve_amount=None, sync=False))
 
 
-def test_protein_prep_start_get_results_returns_in_memory_protein(
+def test_protein_prep_start_recommend_get_recommendation(
     client: DeepOriginClient,
     registered_protein: Protein,
 ) -> None:
-    """start() then get_results() returns Protein with id None and prepared path."""
+    """start() then get_recommendation() returns the component inventory."""
+    assert check_tool_exists(
+        client,
+        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
+        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
+    ), "Protein prep tool not registered on platform (expected key/version)."
+
+    prep = ProteinPrep(registered_protein, client=client)
+    prep.start()
+    recommendation = prep.get_recommendation()
+    assert recommendation.get("source_sha256")
+    assert recommendation.get("analyzer_version")
+    assert recommendation.get("components")
+
+    with pytest.raises(DeepOriginException, match="as_prepare"):
+        prep.get_results()
+
+
+def test_protein_prep_start_as_prepare_get_results(
+    client: DeepOriginClient,
+    registered_protein: Protein,
+) -> None:
+    """Recommend then as_prepare() then get_results() returns an in-memory Protein."""
     assert check_tool_exists(
         client,
         TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
@@ -180,7 +453,17 @@ def test_protein_prep_start_get_results_returns_in_memory_protein(
     ), "Protein prep tool not registered on platform (expected key/version)."
 
     original_id = registered_protein.id
-    prep = ProteinPrep(registered_protein, pdb_id="1EBY", client=client)
+    rec = ProteinPrep(registered_protein, pdb_id="1EBY", client=client)
+    rec.start()
+    if client.env == "local":
+        assert is_success_status(rec.status)
+
+    prep = rec.as_prepare()
+    assert prep.action == "prepare"
+    assert prep.pdb_id == "1EBY"
+    assert prep.selection is not None
+    assert prep.selection["decisions"]["chain:A"] == "keep"
+    assert prep.selection["decisions"]["ligand:LIG:A:100"] == "skip"
     prep.start()
 
     if client.env == "local":
@@ -191,8 +474,32 @@ def test_protein_prep_start_get_results_returns_in_memory_protein(
     assert prepared.id is None
     assert prepared.remote_path == "testing/brd.pdb"
     assert prepared.pdb_id == "1EBY"
-    assert prep.protein.id == original_id
-    assert prep.protein is registered_protein
+    assert rec.protein.id == original_id
+    assert rec.protein is registered_protein
+
+
+def test_protein_prep_start_prepare_payload(
+    client: DeepOriginClient,
+    registered_protein: Protein,
+) -> None:
+    """start() with a selection submits action=prepare."""
+    assert check_tool_exists(
+        client,
+        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
+        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
+    ), "Protein prep tool not registered on platform (expected key/version)."
+
+    prep = ProteinPrep(
+        registered_protein,
+        selection=_SAMPLE_SELECTION,
+        pdb_id="1EBY",
+        client=client,
+    )
+    prep.start()
+    user_inputs = (prep._dto or {}).get("userInputs") or {}
+    assert user_inputs.get("action") == "prepare"
+    assert user_inputs.get("pdb_id") == "1EBY"
+    assert user_inputs.get("selection") == _SAMPLE_SELECTION
 
 
 def test_protein_prep_get_results_from_job_outputs_fallback(
@@ -228,3 +535,61 @@ def test_protein_from_prepared_data_requires_pdb_path() -> None:
             fallback_pdb_id="1EBY",
             fallback_name="brd",
         )
+
+
+def test_protein_prep_pdb_id_required_message() -> None:
+    """Loops-on prepare without pdb_id uses the shared constant."""
+    assert "model_missing_loops=False" in PROTEIN_PREP_PDB_ID_REQUIRED_MSG
+    assert "as_prepare" in PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG
+
+
+def test_protein_prep_run_raises_on_recommend() -> None:
+    """run() is illegal on a recommend instance."""
+    protein = Protein(name="test")
+    prep = ProteinPrep(protein)
+    with pytest.raises(ValueError, match="model_missing_loops=False"):
+        prep.run()
+
+
+def test_protein_prep_run_raises_on_loops_on_prepare() -> None:
+    """run() is illegal when loop modelling is on."""
+    protein = Protein(name="test", pdb_id="1EBY")
+    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION)
+    assert prep.model_missing_loops is True
+    with pytest.raises(ValueError, match="model_missing_loops=False"):
+        prep.run()
+
+
+def test_protein_prep_run_requires_loops_off_message() -> None:
+    """Illegal run() uses the shared constant."""
+    assert "as_prepare(model_missing_loops=False)" in (
+        PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG
+    )
+
+
+def test_protein_prep_run_loops_off_returns_protein(
+    client: DeepOriginClient,
+    registered_protein: Protein,
+) -> None:
+    """run() on loops-off prepare returns an in-memory Protein."""
+    assert check_tool_exists(
+        client,
+        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
+        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
+    ), "Protein prep tool not registered on platform (expected key/version)."
+
+    rec = ProteinPrep(registered_protein, client=client)
+    rec.start()
+    if client.env == "local":
+        assert is_success_status(rec.status)
+
+    prep = rec.as_prepare(model_missing_loops=False)
+    prepared = prep.run()
+
+    assert isinstance(prepared, Protein)
+    assert prepared.id is None
+    assert prepared.remote_path == "testing/brd.pdb"
+    if client.env == "local":
+        assert is_success_status(prep.status)
+        user_inputs = (prep._dto or {}).get("userInputs") or {}
+        assert user_inputs.get("model_missing_loops") is False

--- a/tests/test_protein_prep.py
+++ b/tests/test_protein_prep.py
@@ -6,9 +6,10 @@ import inspect
 import json
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
-from deeporigin.drug_discovery import Protein, ProteinPrep
+from deeporigin.drug_discovery import Protein, ProteinPrep, RecommendationView
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
@@ -52,9 +53,64 @@ _SAMPLE_RECOMMENDATION = {
     ],
     "source_sha256": _SHA256,
 }
+_WATER_RECOMMENDATION = {
+    "analyzer_version": "1.0.0",
+    "chain_id_mapping": {},
+    "components": [
+        *_SAMPLE_RECOMMENDATION["components"],
+        {
+            "author": {"chain_id": "A", "resname": "HOH", "resseq": 310},
+            "evidence": {},
+            "id": "water:A:HOH:310:",
+            "kind": "water",
+            "label": "HOH A 310",
+            "reason": "No pocket context; review whether this water should be retained.",
+            "reason_code": "water_review",
+            "recommendation": "review",
+            "subtype": "crystal",
+        },
+        {
+            "author": {"chain_id": "A", "resname": "HOH", "resseq": 311},
+            "evidence": {"n_coord": 1},
+            "id": "water:A:HOH:311:",
+            "kind": "water",
+            "label": "HOH A 311",
+            "reason": "Water coordinates protein or a kept metal.",
+            "reason_code": "coordinating_water",
+            "recommendation": "keep",
+            "subtype": "coordinating",
+        },
+    ],
+    "source_sha256": _SHA256,
+}
+_WATER_SELECTION = {
+    "analyzer_version": "1.0.0",
+    "decisions": {
+        "chain:A": "keep",
+        "ligand:LIG:A:100": "review",
+        "water:A:HOH:310:": "review",
+        "water:A:HOH:311:": "keep",
+    },
+    "source_sha256": _SHA256,
+}
+
+
+def _prep_with_inventory(
+    *,
+    recommendation: dict = _SAMPLE_RECOMMENDATION,
+    selection: dict = _DRAFT_SELECTION,
+) -> ProteinPrep:
+    """Return a ProteinPrep with analyzer evidence and a draft Selection."""
+    prep = ProteinPrep(protein=Protein(name="test"), selection=selection)
+    prep._recommendation = recommendation
+    return prep
 
 
 def _protein_with_remote(*, pdb_id: str | None = "1EBY") -> Protein:
+    """Return a protein whose remote path avoids upload in payload tests."""
+    protein = Protein(name="test", pdb_id=pdb_id)
+    protein.remote_path = "testing/brd.pdb"
+    return protein
     """Return a protein whose remote path avoids upload in payload tests."""
     protein = Protein(name="test", pdb_id=pdb_id)
     protein.remote_path = "testing/brd.pdb"
@@ -137,16 +193,15 @@ def test_selection_getter_returns_defensive_copy() -> None:
     assert prep.selection == _DRAFT_SELECTION
 
 
-def test_recommendation_getter_returns_defensive_copy() -> None:
-    """Nested mutation of recommendation evidence does not change the object."""
-    prep = ProteinPrep(protein=Protein(name="test"))
-    prep._recommendation = _SAMPLE_RECOMMENDATION
+def test_recommendation_view_raw_is_defensive_copy() -> None:
+    """Mutating RecommendationView.raw does not change stored analyzer evidence."""
+    prep = _prep_with_inventory()
 
     recommendation = prep.recommendation
-    assert recommendation is not None
-    recommendation["components"][0]["label"] = "changed"
-    assert prep.recommendation is not None
-    assert prep.recommendation["components"][0]["label"] == "Chain A"
+    assert isinstance(recommendation, RecommendationView)
+    raw = recommendation.raw
+    raw["components"][0]["label"] = "changed"
+    assert recommendation.raw["components"][0]["label"] == "Chain A"
 
 
 def test_keep_and_skip_change_only_named_components() -> None:
@@ -156,23 +211,22 @@ def test_keep_and_skip_change_only_named_components() -> None:
         selection=_DRAFT_SELECTION,
     )
 
-    prep.skip(["ligand:LIG:A:100"])
-    prep.keep(["chain:A"])
+    assert prep.skip(["ligand:LIG:A:100"]) is prep
+    assert prep.keep(["chain:A"]) is prep
 
     assert prep.selection == _SAMPLE_SELECTION
 
 
-@pytest.mark.parametrize("method_name", ["keep", "skip"])
-def test_keep_and_skip_reject_bare_string(method_name: str) -> None:
-    """Decision methods require an iterable container, not a bare string."""
+def test_keep_accepts_a_single_component_id() -> None:
+    """A bare component id string is treated as a one-element list."""
     prep = ProteinPrep(
         protein=Protein(name="test"),
         selection=_DRAFT_SELECTION,
     )
-    method = getattr(prep, method_name)
 
-    with pytest.raises(TypeError, match="iterable"):
-        method("chain:A")
+    prep.skip("ligand:LIG:A:100")
+
+    assert prep.selection == _SAMPLE_SELECTION
 
 
 def test_keep_reports_all_unknown_component_ids() -> None:
@@ -193,6 +247,193 @@ def test_keep_requires_selection() -> None:
 
     with pytest.raises(ValueError, match=r"recommend\(\)"):
         prep.keep(["chain:A"])
+
+
+def test_recommendation_view_table_columns_and_live_decision() -> None:
+    """The view exposes the locked columns and current Selection Decisions."""
+    prep = _prep_with_inventory()
+
+    df = prep.recommendation()
+
+    assert list(df.columns) == [
+        "id",
+        "kind",
+        "subtype",
+        "label",
+        "recommendation",
+        "decision",
+        "reason",
+        "evidence",
+    ]
+    ligand = df.set_index("id").loc["ligand:LIG:A:100"]
+    assert ligand["recommendation"] == "review"
+    assert ligand["decision"] == "review"
+    prep.keep("ligand:LIG:A:100")
+    updated = prep.recommendation().set_index("id").loc["ligand:LIG:A:100"]
+    assert updated["recommendation"] == "review"
+    assert updated["decision"] == "keep"
+
+
+def test_recommendation_view_filters_by_decision() -> None:
+    """pp.recommendation(decision='review') returns unresolved rows."""
+    prep = _prep_with_inventory()
+
+    df = prep.recommendation(decision="review")
+
+    assert list(df["id"]) == ["ligand:LIG:A:100"]
+
+
+def test_recommendation_view_and_filters() -> None:
+    """View kwargs AND together."""
+    prep = _prep_with_inventory(
+        recommendation=_WATER_RECOMMENDATION,
+        selection=_WATER_SELECTION,
+    )
+
+    df = prep.recommendation(kind="water", decision="review")
+
+    assert list(df["id"]) == ["water:A:HOH:310:"]
+
+
+def test_recommendation_view_rejects_invalid_kind() -> None:
+    """Unknown kind values error instead of matching nothing."""
+    prep = _prep_with_inventory()
+
+    with pytest.raises(ValueError, match="kind must be one of"):
+        prep.recommendation(kind="waters")
+
+
+def test_recommendation_view_has_no_keep() -> None:
+    """keep/skip stay on ProteinPrep; recommend().keep() is not supported."""
+    prep = _prep_with_inventory()
+
+    assert not hasattr(prep.recommendation, "keep")
+    assert not hasattr(prep.recommendation, "skip")
+
+
+def test_keep_kind_is_sugar_for_matching_ids() -> None:
+    """keep(kind='water') overwrites every water Decision, including prior skips."""
+    prep = _prep_with_inventory(
+        recommendation=_WATER_RECOMMENDATION,
+        selection=_WATER_SELECTION,
+    )
+    prep.skip("water:A:HOH:311:")
+
+    prep.keep(kind="water")
+
+    decisions = prep.selection["decisions"]
+    assert decisions["water:A:HOH:310:"] == "keep"
+    assert decisions["water:A:HOH:311:"] == "keep"
+    assert decisions["ligand:LIG:A:100"] == "review"
+
+
+def test_keep_accepts_filtered_dataframe() -> None:
+    """keep(df) uses the DataFrame id column."""
+    prep = _prep_with_inventory(
+        recommendation=_WATER_RECOMMENDATION,
+        selection=_WATER_SELECTION,
+    )
+
+    prep.keep(prep.recommendation(decision="review"))
+
+    decisions = prep.selection["decisions"]
+    assert decisions["ligand:LIG:A:100"] == "keep"
+    assert decisions["water:A:HOH:310:"] == "keep"
+    assert decisions["water:A:HOH:311:"] == "keep"
+
+
+def test_keep_rejects_mixed_ids_and_kwargs() -> None:
+    """Positional ids and matcher kwargs are mutually exclusive."""
+    prep = _prep_with_inventory()
+
+    with pytest.raises(ValueError, match="not both"):
+        prep.keep(["chain:A"], kind="water")
+    assert prep.selection == _DRAFT_SELECTION
+
+
+def test_keep_without_ids_or_kwargs_errors() -> None:
+    """Empty keep() is not sugar for keep([])."""
+    prep = _prep_with_inventory()
+
+    with pytest.raises(ValueError, match="requires component IDs"):
+        prep.keep()
+
+
+def test_keep_invalid_kind_errors() -> None:
+    """Typo'd kind values error; they are not treated as zero matches."""
+    prep = _prep_with_inventory()
+
+    with pytest.raises(ValueError, match="kind must be one of"):
+        prep.keep(kind="waters")
+
+
+def test_keep_zero_matches_is_noop() -> None:
+    """A valid matcher that hits nothing is sugar for an empty id list."""
+    prep = _prep_with_inventory()
+
+    prep.keep(kind="water")
+
+    assert prep.selection == _DRAFT_SELECTION
+
+
+def test_keep_kind_without_recommendation_uses_id_prefix() -> None:
+    """kind= can match Selection ids when analyzer evidence is absent."""
+    prep = ProteinPrep(protein=Protein(name="test"), selection=_DRAFT_SELECTION)
+
+    prep.keep(kind="ligand")
+
+    assert prep.selection["decisions"]["ligand:LIG:A:100"] == "keep"
+    assert prep.selection["decisions"]["chain:A"] == "keep"
+
+
+def test_keep_subtype_without_recommendation_errors() -> None:
+    """subtype= needs analyzer evidence."""
+    prep = ProteinPrep(protein=Protein(name="test"), selection=_DRAFT_SELECTION)
+
+    with pytest.raises(ValueError, match="subtype="):
+        prep.keep(subtype="crystal")
+
+
+def test_recommendation_view_filters_by_analyzer_tag() -> None:
+    """recommendation= filters frozen analyzer tags, not live Decisions."""
+    prep = _prep_with_inventory()
+    prep.keep("ligand:LIG:A:100")
+
+    df = prep.recommendation(recommendation="review")
+
+    assert list(df["id"]) == ["ligand:LIG:A:100"]
+    assert list(df["decision"]) == ["keep"]
+
+
+def test_keep_rejects_uncalled_view() -> None:
+    """The uncalled view is not a DataFrame of ids."""
+    prep = _prep_with_inventory()
+
+    with pytest.raises(TypeError, match="not the recommendation view"):
+        prep.keep(prep.recommendation)
+
+
+def test_keep_dataframe_requires_id_column() -> None:
+    """DataFrame matchers must expose an id column."""
+    prep = _prep_with_inventory()
+
+    with pytest.raises(ValueError, match="id"):
+        prep.keep(pd.DataFrame({"kind": ["water"]}))
+
+
+def test_skip_decision_review_resolves_reviews() -> None:
+    """skip(decision='review') is sugar for skipping unresolved Components."""
+    prep = _prep_with_inventory(
+        recommendation=_WATER_RECOMMENDATION,
+        selection=_WATER_SELECTION,
+    )
+
+    prep.skip(decision="review")
+
+    decisions = prep.selection["decisions"]
+    assert decisions["ligand:LIG:A:100"] == "skip"
+    assert decisions["water:A:HOH:310:"] == "skip"
+    assert decisions["chain:A"] == "keep"
 
 
 def test_prepare_requires_selection_before_upload() -> None:
@@ -343,7 +584,7 @@ def test_repr_uses_user_concepts_not_action() -> None:
     assert "action" not in text
     assert "1 keep, 1 review, 0 skip" in text
     assert "recommendation" in text
-    assert "available" in text
+    assert "2 components" in text
 
 
 def test_repr_adds_durable_execution_state() -> None:
@@ -387,7 +628,7 @@ def test_from_dto_rehydrates_recommendation(
     prep = ProteinPrep.from_dto(dto, client=client)
 
     assert prep._operation_kind == "recommend"
-    assert prep.recommendation is not None
+    assert isinstance(prep.recommendation, RecommendationView)
     assert prep.selection == _DRAFT_SELECTION
     with pytest.raises(DeepOriginException, match="did not produce"):
         prep.get_results(dto)
@@ -434,7 +675,7 @@ def test_recommend_updates_same_object_without_id(
 
     result = prep.recommend()
 
-    assert result is None
+    assert isinstance(result, RecommendationView)
     assert prep.id is None
     assert prep.status is None
     assert prep.recommendation is not None

--- a/tests/test_protein_prep.py
+++ b/tests/test_protein_prep.py
@@ -2,27 +2,27 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from pathlib import Path
 
 import pytest
 
 from deeporigin.drug_discovery import Protein, ProteinPrep
-from deeporigin.drug_discovery.protein_prep import selection_from_recommendation
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
-from deeporigin.utils.constants import (
-    PROTEIN_PREP_PDB_ID_REQUIRED_MSG,
-    PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG,
-    PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG,
-)
 from tests.conftest import check_tool_exists
 
 _SHA256 = "a" * 64
 _SAMPLE_SELECTION = {
     "analyzer_version": "1.0.0",
     "decisions": {"chain:A": "keep", "ligand:LIG:A:100": "skip"},
+    "source_sha256": _SHA256,
+}
+_DRAFT_SELECTION = {
+    "analyzer_version": "1.0.0",
+    "decisions": {"chain:A": "keep", "ligand:LIG:A:100": "review"},
     "source_sha256": _SHA256,
 }
 _SAMPLE_RECOMMENDATION = {
@@ -55,541 +55,435 @@ _SAMPLE_RECOMMENDATION = {
 
 
 def _protein_with_remote(*, pdb_id: str | None = "1EBY") -> Protein:
-    """In-memory protein with a remote path so payload tests skip upload."""
+    """Return a protein whose remote path avoids upload in payload tests."""
     protein = Protein(name="test", pdb_id=pdb_id)
     protein.remote_path = "testing/brd.pdb"
     return protein
 
 
-def test_protein_prep_defaults_to_recommend() -> None:
-    """Constructor without selection is a recommend run; pdb_id is optional."""
-    protein = Protein(name="test")
-    prep = ProteinPrep(protein)
-    assert prep.action == "recommend"
-    assert prep.pdb_id is None
-    assert prep.selection is None
-    assert prep.model_missing_loops is True
+def _execution_fixture(name: str) -> dict:
+    """Load a Protein Prep execution fixture."""
+    path = Path(__file__).parent / "fixtures/executions" / name
+    return json.loads(path.read_text())
 
 
-def test_protein_prep_infers_pdb_id_from_protein() -> None:
-    """Constructor stores protein.pdb_id for later prepare."""
+def test_protein_prep_constructor_has_configuration_defaults() -> None:
+    """Construction creates unbound configuration with loops enabled."""
     protein = Protein(name="test", pdb_id="1EBY")
-    prep = ProteinPrep(protein)
+    prep = ProteinPrep(protein=protein)
+
+    assert prep.protein is protein
     assert prep.pdb_id == "1EBY"
+    assert prep.selection is None
+    assert prep.recommendation is None
+    assert prep.model_missing_loops is True
+    assert prep.id is None
+    assert not hasattr(prep, "action")
 
 
-def test_protein_prep_prepare_requires_pdb_id_when_loops_on() -> None:
-    """Prepare with loop modelling raises when neither source has pdb_id."""
-    protein = Protein(name="test")
-    with pytest.raises(ValueError, match="pdb_id is required"):
-        ProteinPrep(protein, selection=_SAMPLE_SELECTION)
+def test_protein_is_constructor_only() -> None:
+    """The input protein cannot be replaced after construction."""
+    prep = ProteinPrep(protein=Protein(name="test"))
+
+    with pytest.raises(AttributeError):
+        prep.protein = Protein(name="other")  # type: ignore[misc]
 
 
-def test_protein_prep_prepare_loops_off_allows_missing_pdb_id() -> None:
-    """Prepare with model_missing_loops=False does not require pdb_id."""
-    protein = Protein(name="test")
-    prep = ProteinPrep(
-        protein,
-        selection=_SAMPLE_SELECTION,
-        model_missing_loops=False,
-    )
-    assert prep.action == "prepare"
+def test_pdb_id_is_mutable_before_prepare() -> None:
+    """PDB ID can be corrected or cleared before durable submission."""
+    prep = ProteinPrep(protein=Protein(name="test"))
+
+    prep.pdb_id = "2ABC"
+    assert prep.pdb_id == "2ABC"
+    prep.pdb_id = None
     assert prep.pdb_id is None
-    assert prep.model_missing_loops is False
 
 
-def test_protein_prep_rejects_invalid_pdb_id() -> None:
-    """Constructor rejects PDB IDs that are not 4 alphanumeric characters."""
+@pytest.mark.parametrize("pdb_id", ["1EB", "1EBYX", "1EB!"])
+def test_protein_prep_rejects_invalid_pdb_id(pdb_id: str) -> None:
+    """PDB IDs must contain exactly four alphanumeric characters."""
     protein = Protein(name="test")
+
     with pytest.raises(ValueError, match="4-character"):
-        ProteinPrep(protein, pdb_id="1EB")
-    with pytest.raises(ValueError, match="4-character"):
-        ProteinPrep(protein, pdb_id="1EBYX")
-    with pytest.raises(ValueError, match="4-character"):
-        ProteinPrep(protein, pdb_id="1EB!")
+        ProteinPrep(protein=protein, pdb_id=pdb_id)
 
 
-def test_protein_prep_explicit_pdb_id_overrides_protein() -> None:
-    """Constructor pdb_id= wins over protein.pdb_id."""
-    protein = Protein(name="test", pdb_id="1ABC")
-    prep = ProteinPrep(protein, pdb_id="2XYZ")
-    assert prep.pdb_id == "2XYZ"
-
-
-def test_protein_prep_recommend_rejects_loops_off() -> None:
-    """model_missing_loops=False is invalid on a recommend run."""
-    protein = Protein(name="test")
-    with pytest.raises(ValueError, match="model_missing_loops=False"):
-        ProteinPrep(protein, model_missing_loops=False)
-
-
-def test_protein_prep_prepare_requires_selection() -> None:
-    """Explicit action='prepare' without selection raises."""
-    protein = Protein(name="test", pdb_id="1EBY")
-    with pytest.raises(ValueError, match="requires a selection"):
-        ProteinPrep(protein, action="prepare")
-
-
-def test_protein_prep_recommend_rejects_selection() -> None:
-    """Explicit action='recommend' with selection raises."""
-    protein = Protein(name="test")
-    with pytest.raises(ValueError, match="does not accept a selection"):
-        ProteinPrep(protein, action="recommend", selection=_SAMPLE_SELECTION)
-
-
-def test_protein_prep_selection_copy_is_independent() -> None:
-    """Constructor copies selection so later mutations do not leak."""
-    protein = Protein(name="test", pdb_id="1EBY")
+def test_selection_assignment_accepts_review_and_copies() -> None:
+    """Draft Selection assignment accepts review without retaining aliases."""
     selection = {
         "analyzer_version": "1.0.0",
-        "decisions": {"chain:A": "keep"},
+        "decisions": {
+            "chain:A": "keep",
+            "ligand:LIG:A:100": "review",
+        },
         "source_sha256": _SHA256,
     }
-    prep = ProteinPrep(protein, selection=selection)
-    selection["decisions"]["chain:A"] = "skip"
-    assert prep.selection is not None
-    assert prep.selection["decisions"]["chain:A"] == "keep"
+    prep = ProteinPrep(protein=Protein(name="test"), selection=selection)
+
+    selection["decisions"]["ligand:LIG:A:100"] = "skip"
+    assert prep.selection == _DRAFT_SELECTION
 
 
-def test_selection_from_recommendation_resolves_review_to_skip() -> None:
-    """Reviews become skip by default; keep/skip pass through."""
-    selection = selection_from_recommendation(_SAMPLE_RECOMMENDATION)
-    assert selection["source_sha256"] == _SHA256
-    assert selection["analyzer_version"] == "1.0.0"
-    assert selection["decisions"] == {
-        "chain:A": "keep",
-        "ligand:LIG:A:100": "skip",
-    }
-
-
-def test_selection_from_recommendation_can_keep_reviews() -> None:
-    """resolve_review_as='keep' maps review components to keep."""
-    selection = selection_from_recommendation(
-        _SAMPLE_RECOMMENDATION,
-        resolve_review_as="keep",
+def test_selection_getter_returns_defensive_copy() -> None:
+    """Nested mutation of a Selection read does not change the object."""
+    prep = ProteinPrep(
+        protein=Protein(name="test"),
+        selection=_DRAFT_SELECTION,
     )
-    assert selection["decisions"]["ligand:LIG:A:100"] == "keep"
+
+    selection = prep.selection
+    assert selection is not None
+    selection["decisions"]["ligand:LIG:A:100"] = "skip"
+    assert prep.selection == _DRAFT_SELECTION
 
 
-def test_protein_prep_from_recommendation_builds_prepare() -> None:
-    """from_recommendation produces a prepare instance with a selection."""
-    protein = Protein(name="test", pdb_id="1EBY")
-    prep = ProteinPrep.from_recommendation(protein, _SAMPLE_RECOMMENDATION)
-    assert prep.action == "prepare"
-    assert prep.pdb_id == "1EBY"
+def test_recommendation_getter_returns_defensive_copy() -> None:
+    """Nested mutation of recommendation evidence does not change the object."""
+    prep = ProteinPrep(protein=Protein(name="test"))
+    prep._recommendation = _SAMPLE_RECOMMENDATION
+
+    recommendation = prep.recommendation
+    assert recommendation is not None
+    recommendation["components"][0]["label"] = "changed"
+    assert prep.recommendation is not None
+    assert prep.recommendation["components"][0]["label"] == "Chain A"
+
+
+def test_keep_and_skip_change_only_named_components() -> None:
+    """Domain editing methods preserve decisions not named by the caller."""
+    prep = ProteinPrep(
+        protein=Protein(name="test"),
+        selection=_DRAFT_SELECTION,
+    )
+
+    prep.skip(["ligand:LIG:A:100"])
+    prep.keep(["chain:A"])
+
     assert prep.selection == _SAMPLE_SELECTION
 
 
-def test_protein_prep_repr_lists_parameters() -> None:
-    """repr/str show constructor parameters including action."""
-    protein = Protein(name="brd", pdb_id="1EBY")
-    prep = ProteinPrep(protein)
-    text = repr(prep)
-
-    assert text == str(prep)
-    assert text.startswith("ProteinPrep")
-    assert "action" in text
-    assert "recommend" in text
-    assert "pdb_id" in text
-    assert "1EBY" in text
-    assert "selection" in text
-    assert "(none)" in text
-    assert "model_missing_loops" in text
-    assert "tool_version" in text
-    assert "brd" in text
-    names = [name for name, _ in prep._parameter_rows()]
-    assert "id" not in names
-    assert "status" not in names
-
-
-def test_protein_prep_repr_shows_selection_and_execution_fields() -> None:
-    """repr shows selection counts and id/status when set."""
-    protein = Protein(name="brd", id="prot-1", pdb_id="1EBY")
-    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION)
-    text = repr(prep)
-    assert "prepare" in text
-    assert "1 keep, 1 skip" in text
-    assert "id='prot-1'" in text
-
-    prep._id = "exec-abc"
-    prep.status = "Succeeded"
-    prep._name = "my-prep"
-    later = repr(prep)
-    assert "exec-abc" in later
-    assert "Succeeded" in later
-    assert "my-prep" in later
-
-
-def test_protein_prep_repr_html_escapes_and_lists_parameters() -> None:
-    """_repr_html_ is an HTML table of parameters with escaped values."""
-    protein = Protein(name="<script>", pdb_id="1EBY")
-    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION)
-    html = prep._repr_html_()
-
-    assert "<table" in html
-    assert "selection" in html
-    assert "pdb_id" in html
-    assert "1 keep, 1 skip" in html
-    assert "<script>" not in html
-    assert "&lt;script&gt;" in html
-
-
-def test_protein_prep_recommend_payload_omits_v1_fields() -> None:
-    """Recommend POST body is action + protein only."""
-    protein = _protein_with_remote()
-    protein.id = "prot-1"
-    prep = ProteinPrep(protein, pdb_id="1EBY")
-    payload = prep._make_payload(approve_amount=None, sync=False)
-    assert payload["inputs"] == {
-        "action": "recommend",
-        "protein": {"file_path": "testing/brd.pdb", "id": "prot-1"},
-    }
-    assert payload["sync"] is False
-    assert "approveAmount" not in payload
-
-
-def test_protein_prep_prepare_payload_includes_selection() -> None:
-    """Prepare POST body includes action, protein, pdb_id, and selection."""
-    protein = _protein_with_remote()
-    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION, pdb_id="1EBY")
-    payload = prep._make_payload(approve_amount=None, sync=False)
-    inputs = payload["inputs"]
-    assert payload["sync"] is False
-    assert inputs["action"] == "prepare"
-    assert inputs["pdb_id"] == "1EBY"
-    assert inputs["selection"] == _SAMPLE_SELECTION
-    assert inputs["protein"]["file_path"] == "testing/brd.pdb"
-    assert "model_missing_loops" not in inputs
-    assert "keep_chain_ids" not in inputs
-
-
-def test_protein_prep_prepare_loops_off_payload() -> None:
-    """Loops-off prepare sends model_missing_loops=false and omits pdb_id."""
-    protein = _protein_with_remote(pdb_id=None)
+@pytest.mark.parametrize("method_name", ["keep", "skip"])
+def test_keep_and_skip_reject_bare_string(method_name: str) -> None:
+    """Decision methods require an iterable container, not a bare string."""
     prep = ProteinPrep(
-        protein,
-        selection=_SAMPLE_SELECTION,
+        protein=Protein(name="test"),
+        selection=_DRAFT_SELECTION,
+    )
+    method = getattr(prep, method_name)
+
+    with pytest.raises(TypeError, match="iterable"):
+        method("chain:A")
+
+
+def test_keep_reports_all_unknown_component_ids() -> None:
+    """Decision editing rejects unknown IDs without partially mutating."""
+    prep = ProteinPrep(
+        protein=Protein(name="test"),
+        selection=_DRAFT_SELECTION,
+    )
+
+    with pytest.raises(ValueError, match="missing:A, missing:B"):
+        prep.keep(["missing:B", "missing:A"])
+    assert prep.selection == _DRAFT_SELECTION
+
+
+def test_keep_requires_selection() -> None:
+    """Decision editing guides callers to obtain a Selection first."""
+    prep = ProteinPrep(protein=Protein(name="test"))
+
+    with pytest.raises(ValueError, match=r"recommend\(\)"):
+        prep.keep(["chain:A"])
+
+
+def test_prepare_requires_selection_before_upload() -> None:
+    """Prepare cannot begin until recommendation or assignment provides Selection."""
+    prep = ProteinPrep(
+        protein=Protein(name="test"),
         model_missing_loops=False,
     )
-    payload = prep._make_payload(approve_amount=None, sync=True)
-    inputs = payload["inputs"]
-    assert payload["sync"] is True
-    assert inputs["action"] == "prepare"
-    assert inputs["model_missing_loops"] is False
-    assert "pdb_id" not in inputs
-    assert "sync" not in inputs
+
+    with pytest.raises(ValueError, match="no selection"):
+        prep.run()
 
 
-def test_protein_prep_start_rejects_non_none_status(
-    registered_protein: Protein,
-) -> None:
-    """start() refuses to resubmit when an execution already exists."""
-    prep = ProteinPrep(registered_protein, pdb_id="1EBY")
-    prep._id = "exec-existing"
-    prep.status = "Running"
+def test_prepare_lists_unresolved_reviews() -> None:
+    """Prepare reports every unresolved review component."""
+    selection = {
+        **_DRAFT_SELECTION,
+        "decisions": {
+            "chain:A": "review",
+            "ligand:LIG:A:100": "review",
+        },
+    }
+    prep = ProteinPrep(
+        protein=Protein(name="test"),
+        selection=selection,
+        model_missing_loops=False,
+    )
 
-    with pytest.raises(ValueError, match="already in 'Running' state"):
+    with pytest.raises(ValueError, match=r"chain:A.*ligand:LIG:A:100"):
+        prep.run()
+
+
+def test_run_requires_loops_off() -> None:
+    """Blocking prepare directs loops-on callers to start."""
+    prep = ProteinPrep(
+        protein=Protein(name="test", pdb_id="1EBY"),
+        selection=_SAMPLE_SELECTION,
+    )
+
+    with pytest.raises(ValueError, match=r"Use start\(\)"):
+        prep.run()
+
+
+def test_start_requires_pdb_id_when_loops_enabled() -> None:
+    """Asynchronous loops-on prepare requires a PDB ID."""
+    prep = ProteinPrep(
+        protein=Protein(name="test"),
+        selection=_SAMPLE_SELECTION,
+    )
+
+    with pytest.raises(ValueError, match="pdb_id is required"):
         prep.start()
 
 
-def test_protein_prep_get_results_requires_id() -> None:
-    """get_results() raises when no execution has been started."""
-    protein = Protein(name="test", pdb_id="1EBY")
-    prep = ProteinPrep(protein)
-    with pytest.raises(ValueError, match="no execution"):
-        prep.get_results()
-
-
-def test_protein_prep_from_dto_maps_prepare_fields(client: DeepOriginClient) -> None:
-    """from_dto rehydrates protein, action, pdb_id, and selection."""
-    fixture_path = (
-        Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
+def test_configuration_freezes_permanently_after_id() -> None:
+    """All supported configuration mutation fails once an ID is present."""
+    prep = ProteinPrep(
+        protein=Protein(name="test", pdb_id="1EBY"),
+        selection=_SAMPLE_SELECTION,
     )
-    dto = json.loads(fixture_path.read_text())
+    prep._id = "exec-locked"
+
+    with pytest.raises(AttributeError, match="execution id is already set"):
+        prep.model_missing_loops = False
+    with pytest.raises(AttributeError, match="execution id is already set"):
+        prep.pdb_id = "2ABC"
+    with pytest.raises(AttributeError, match="execution id is already set"):
+        prep.selection = _SAMPLE_SELECTION
+    with pytest.raises(AttributeError, match="execution id is already set"):
+        prep.keep(["chain:A"])
+    with pytest.raises(AttributeError, match="execution id is already set"):
+        prep.recommend()
+
+
+def test_removed_api_is_absent() -> None:
+    """The old two-object and quote-oriented surface is removed."""
+    prep = ProteinPrep(protein=Protein(name="test"))
+
+    assert not hasattr(prep, "as_prepare")
+    assert not hasattr(prep, "from_recommendation")
+    assert not hasattr(prep, "get_recommendation")
+    assert not hasattr(prep, "selection_from_recommendation")
+    assert list(inspect.signature(prep.run).parameters) == []
+    assert list(inspect.signature(prep.start).parameters) == []
+
+
+def test_recommend_payload_is_blocking_and_minimal() -> None:
+    """Internal recommend payload contains only action and protein input."""
+    protein = _protein_with_remote()
+    protein.id = "prot-1"
+    prep = ProteinPrep(protein=protein)
+
+    payload = prep._make_protein_prep_payload(action="recommend", sync=True)
+
+    assert payload == {
+        "inputs": {
+            "action": "recommend",
+            "protein": {"file_path": "testing/brd.pdb", "id": "prot-1"},
+        },
+        "metadata": {},
+        "outputs": {},
+        "sync": True,
+    }
+
+
+def test_prepare_payload_contains_resolved_selection() -> None:
+    """Prepare payload contains current configuration and no billing fields."""
+    prep = ProteinPrep(
+        protein=_protein_with_remote(),
+        pdb_id="1EBY",
+        selection=_SAMPLE_SELECTION,
+    )
+
+    payload = prep._make_protein_prep_payload(action="prepare", sync=False)
+
+    assert payload["sync"] is False
+    assert payload["inputs"]["action"] == "prepare"
+    assert payload["inputs"]["selection"] == _SAMPLE_SELECTION
+    assert payload["inputs"]["pdb_id"] == "1EBY"
+    assert "model_missing_loops" not in payload["inputs"]
+    assert "approveAmount" not in payload
+
+
+def test_loops_off_payload_omits_pdb_id() -> None:
+    """Loops-off prepare sends the opt-out without requiring a PDB ID."""
+    prep = ProteinPrep(
+        protein=_protein_with_remote(pdb_id=None),
+        selection=_SAMPLE_SELECTION,
+        model_missing_loops=False,
+    )
+
+    payload = prep._make_protein_prep_payload(action="prepare", sync=True)
+
+    assert payload["inputs"]["model_missing_loops"] is False
+    assert "pdb_id" not in payload["inputs"]
+
+
+def test_repr_uses_user_concepts_not_action() -> None:
+    """Text display summarizes configuration without exposing action."""
+    prep = ProteinPrep(
+        protein=Protein(name="brd", pdb_id="1EBY"),
+        selection=_DRAFT_SELECTION,
+    )
+    prep._recommendation = _SAMPLE_RECOMMENDATION
+
+    text = repr(prep)
+
+    assert "action" not in text
+    assert "1 keep, 1 review, 0 skip" in text
+    assert "recommendation" in text
+    assert "available" in text
+
+
+def test_repr_adds_durable_execution_state() -> None:
+    """Text display adds ID, status, and progress for a bound object."""
+    prep = ProteinPrep(
+        protein=Protein(name="brd", pdb_id="1EBY"),
+        selection=_SAMPLE_SELECTION,
+    )
+    prep._id = "exec-abc"
+    prep.status = "Running"
+    prep.progress = {"percent": 25}
+
+    text = repr(prep)
+
+    assert "exec-abc" in text
+    assert "Running" in text
+    assert "25" in text
+
+
+def test_from_dto_rehydrates_prepare_without_public_action(
+    client: DeepOriginClient,
+) -> None:
+    """Historical prepare DTOs retain inputs and private operation kind."""
+    dto = _execution_fixture("protein-prep-test-execution.json")
 
     prep = ProteinPrep.from_dto(dto, client=client)
 
     assert prep.id == dto["executionId"]
-    assert prep.status == dto["status"]
-    assert prep.action == "prepare"
-    assert prep.pdb_id == "1EBY"
+    assert prep._operation_kind == "prepare"
     assert prep.selection == _SAMPLE_SELECTION
-    assert prep.protein.remote_path == "testing/brd.pdb"
+    assert prep.recommendation is None
+    assert not hasattr(prep, "action")
 
 
-def test_protein_prep_from_dto_maps_recommend_fields(client: DeepOriginClient) -> None:
-    """from_dto rehydrates a recommend execution without a selection."""
-    fixture_path = (
-        Path(__file__).parent
-        / "fixtures/executions/protein-prep-recommend-execution.json"
-    )
-    dto = json.loads(fixture_path.read_text())
-
-    prep = ProteinPrep.from_dto(dto, client=client)
-
-    assert prep.action == "recommend"
-    assert prep.selection is None
-    rec = prep.get_recommendation(dto)
-    assert rec["source_sha256"] == _SHA256
-    assert rec["components"][0]["id"] == "chain:A"
-
-
-def test_protein_prep_from_dto_v1_keep_lists_still_get_results(
+def test_from_dto_rehydrates_recommendation(
     client: DeepOriginClient,
 ) -> None:
-    """v1 userInputs (no action) rehydrate as prepare so get_results still works."""
-    fixture_path = (
-        Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
-    )
-    dto = json.loads(fixture_path.read_text())
+    """Historical recommend DTOs expose evidence and draft Selection."""
+    dto = _execution_fixture("protein-prep-recommend-execution.json")
+
+    prep = ProteinPrep.from_dto(dto, client=client)
+
+    assert prep._operation_kind == "recommend"
+    assert prep.recommendation is not None
+    assert prep.selection == _DRAFT_SELECTION
+    with pytest.raises(DeepOriginException, match="did not produce"):
+        prep.get_results(dto)
+
+
+def test_from_dto_v1_prepare_still_gets_results(
+    client: DeepOriginClient,
+) -> None:
+    """Legacy inputs without action continue to rehydrate as prepare."""
+    dto = _execution_fixture("protein-prep-test-execution.json")
     dto["userInputs"] = {
         "keep_chain_ids": ["A"],
-        "keep_cofactor_ids": ["MG"],
-        "keep_water_residue_names": ["HOH"],
         "pdb_id": "1EBY",
         "protein": {"file_path": "testing/brd.pdb", "id": "brd"},
-        "remove_ligand_ids": ["LIG"],
     }
+
     prep = ProteinPrep.from_dto(dto, client=client)
-    assert prep.action == "prepare"
-    assert prep.selection is None
     prepared = prep.get_results(dto)
+
+    assert prep._operation_kind == "prepare"
     assert isinstance(prepared, Protein)
     assert prepared.remote_path == "testing/brd.pdb"
 
 
-def test_protein_prep_from_dto_initializes_notebook_watch_state(
-    client: DeepOriginClient,
-) -> None:
-    """from_dto skips __init__; notebook watch attrs must exist for stop_watching."""
-    fixture_path = (
-        Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
-    )
-    dto = json.loads(fixture_path.read_text())
+def test_get_results_requires_durable_id() -> None:
+    """Result retrieval is unavailable before prepare submission."""
+    prep = ProteinPrep(protein=Protein(name="test"))
 
-    prep = ProteinPrep.from_dto(dto, client=client)
-    assert prep._watch_task is None
-    assert prep._display_id is None
-    assert prep._last_html is None
-    prep.stop_watching()
-
-
-def test_protein_prep_from_dto_rejects_tool_key_mismatch(
-    client: DeepOriginClient,
-) -> None:
-    """from_dto raises when the DTO tool key is not protein-prep."""
-    fixture_path = (
-        Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
-    )
-    dto = json.loads(fixture_path.read_text())
-    dto["tool"] = {"key": "deeporigin.pocket-finder", "version": "1.0.0"}
-
-    with pytest.raises(ValueError, match="tool key mismatch"):
-        ProteinPrep.from_dto(dto, client=client)
-
-
-def test_protein_prep_start_submits_recommend_payload(
-    client: DeepOriginClient,
-    registered_protein: Protein,
-) -> None:
-    """start() without selection submits action=recommend and stores id/status."""
-    assert check_tool_exists(
-        client,
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
-    ), "Protein prep tool not registered on platform (expected key/version)."
-
-    prep = ProteinPrep(registered_protein, pdb_id="1EBY", client=client)
-    prep.start()
-
-    assert prep.id is not None
-    assert prep.status is not None
-    dto = prep._dto or {}
-    assert (
-        dto.get("tool", {}).get("key")
-        == TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"]
-    )
-    user_inputs = dto.get("userInputs") or {}
-    assert user_inputs.get("action") == "recommend"
-    assert "pdb_id" not in user_inputs
-    assert "keep_chain_ids" not in user_inputs
-    assert "selection" not in user_inputs
-    protein_input = user_inputs.get("protein") or {}
-    assert protein_input.get("id") == registered_protein.id
-    assert protein_input.get("file_path") == registered_protein.remote_path
-
-
-def test_protein_prep_start_recommend_get_recommendation(
-    client: DeepOriginClient,
-    registered_protein: Protein,
-) -> None:
-    """start() then get_recommendation() returns the component inventory."""
-    assert check_tool_exists(
-        client,
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
-    ), "Protein prep tool not registered on platform (expected key/version)."
-
-    prep = ProteinPrep(registered_protein, client=client)
-    prep.start()
-    recommendation = prep.get_recommendation()
-    assert recommendation.get("source_sha256")
-    assert recommendation.get("analyzer_version")
-    assert recommendation.get("components")
-
-    with pytest.raises(DeepOriginException, match="as_prepare"):
+    with pytest.raises(ValueError, match="no execution"):
         prep.get_results()
 
 
-def test_protein_prep_start_as_prepare_get_results(
+def test_recommend_updates_same_object_without_id(
     client: DeepOriginClient,
     registered_protein: Protein,
 ) -> None:
-    """Recommend then as_prepare() then get_results() returns an in-memory Protein."""
+    """Blocking recommendation mutates configuration but does not bind ID."""
     assert check_tool_exists(
         client,
         TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
         TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
-    ), "Protein prep tool not registered on platform (expected key/version)."
+    )
+    prep = ProteinPrep(protein=registered_protein, client=client)
 
-    original_id = registered_protein.id
-    rec = ProteinPrep(registered_protein, pdb_id="1EBY", client=client)
-    rec.start()
-    if client.env == "local":
-        assert is_success_status(rec.status)
+    result = prep.recommend()
 
-    prep = rec.as_prepare()
-    assert prep.action == "prepare"
-    assert prep.pdb_id == "1EBY"
+    assert result is None
+    assert prep.id is None
+    assert prep.status is None
+    assert prep.recommendation is not None
     assert prep.selection is not None
     assert prep.selection["decisions"]["chain:A"] == "keep"
-    assert prep.selection["decisions"]["ligand:LIG:A:100"] == "skip"
-    prep.start()
-
-    if client.env == "local":
-        assert is_success_status(prep.status)
-    prepared = prep.get_results()
-
-    assert isinstance(prepared, Protein)
-    assert prepared.id is None
-    assert prepared.remote_path == "testing/brd.pdb"
-    assert prepared.pdb_id == "1EBY"
-    assert rec.protein.id == original_id
-    assert rec.protein is registered_protein
+    assert prep.selection["decisions"]["ligand:LIG:A:100"] == "review"
 
 
-def test_protein_prep_start_prepare_payload(
+def test_recommend_then_run_loops_off_returns_protein(
     client: DeepOriginClient,
     registered_protein: Protein,
 ) -> None:
-    """start() with a selection submits action=prepare."""
-    assert check_tool_exists(
-        client,
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
-    ), "Protein prep tool not registered on platform (expected key/version)."
-
+    """One object recommends, resolves review, and prepares synchronously."""
     prep = ProteinPrep(
-        registered_protein,
-        selection=_SAMPLE_SELECTION,
-        pdb_id="1EBY",
+        protein=registered_protein,
+        model_missing_loops=False,
         client=client,
     )
-    prep.start()
-    user_inputs = (prep._dto or {}).get("userInputs") or {}
-    assert user_inputs.get("action") == "prepare"
-    assert user_inputs.get("pdb_id") == "1EBY"
-    assert user_inputs.get("selection") == _SAMPLE_SELECTION
+    prep.recommend()
+    prep.skip(["ligand:LIG:A:100"])
 
-
-def test_protein_prep_get_results_from_job_outputs_fallback(
-    client: DeepOriginClient,
-) -> None:
-    """get_results parses jobOutputs.protein when explorer rows are absent."""
-    fixture_path = (
-        Path(__file__).parent / "fixtures/executions/protein-prep-test-execution.json"
-    )
-    dto = json.loads(fixture_path.read_text())
-    prep = ProteinPrep.from_dto(dto, client=client)
-    prepared = prep.get_results(dto)
-
-    assert isinstance(prepared, Protein)
-    assert prepared.id is None
-    assert prepared.remote_path == "testing/brd.pdb"
-
-
-def test_protein_from_prepared_data_requires_pdb_path() -> None:
-    """Prepared-protein payloads without a PDB path are rejected."""
-    from deeporigin.drug_discovery.protein_prep import _protein_from_prepared_data
-    from deeporigin.utils.constants import PROTEIN_PREP_NO_OUTPUT_PATHS_MSG
-
-    with pytest.raises(ValueError, match="prepared PDB"):
-        _protein_from_prepared_data(
-            {},
-            fallback_pdb_id="1EBY",
-            fallback_name="brd",
-        )
-    with pytest.raises(ValueError, match=PROTEIN_PREP_NO_OUTPUT_PATHS_MSG):
-        _protein_from_prepared_data(
-            {"protein_pdb_file_path": "  "},
-            fallback_pdb_id="1EBY",
-            fallback_name="brd",
-        )
-
-
-def test_protein_prep_pdb_id_required_message() -> None:
-    """Loops-on prepare without pdb_id uses the shared constant."""
-    assert "model_missing_loops=False" in PROTEIN_PREP_PDB_ID_REQUIRED_MSG
-    assert "as_prepare" in PROTEIN_PREP_RECOMMEND_NOT_PREPARE_MSG
-
-
-def test_protein_prep_run_raises_on_recommend() -> None:
-    """run() is illegal on a recommend instance."""
-    protein = Protein(name="test")
-    prep = ProteinPrep(protein)
-    with pytest.raises(ValueError, match="model_missing_loops=False"):
-        prep.run()
-
-
-def test_protein_prep_run_raises_on_loops_on_prepare() -> None:
-    """run() is illegal when loop modelling is on."""
-    protein = Protein(name="test", pdb_id="1EBY")
-    prep = ProteinPrep(protein, selection=_SAMPLE_SELECTION)
-    assert prep.model_missing_loops is True
-    with pytest.raises(ValueError, match="model_missing_loops=False"):
-        prep.run()
-
-
-def test_protein_prep_run_requires_loops_off_message() -> None:
-    """Illegal run() uses the shared constant."""
-    assert "as_prepare(model_missing_loops=False)" in (
-        PROTEIN_PREP_RUN_REQUIRES_LOOPS_OFF_MSG
-    )
-
-
-def test_protein_prep_run_loops_off_returns_protein(
-    client: DeepOriginClient,
-    registered_protein: Protein,
-) -> None:
-    """run() on loops-off prepare returns an in-memory Protein."""
-    assert check_tool_exists(
-        client,
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_key"],
-        TOOL_KEYS_AND_VERSIONS["protein_prep"]["tool_version"],
-    ), "Protein prep tool not registered on platform (expected key/version)."
-
-    rec = ProteinPrep(registered_protein, client=client)
-    rec.start()
-    if client.env == "local":
-        assert is_success_status(rec.status)
-
-    prep = rec.as_prepare(model_missing_loops=False)
     prepared = prep.run()
 
     assert isinstance(prepared, Protein)
     assert prepared.id is None
     assert prepared.remote_path == "testing/brd.pdb"
+    assert prep.id is not None
     if client.env == "local":
         assert is_success_status(prep.status)
-        user_inputs = (prep._dto or {}).get("userInputs") or {}
-        assert user_inputs.get("model_missing_loops") is False
+        inputs = (prep._dto or {}).get("userInputs") or {}
+        assert inputs["action"] == "prepare"
+        assert inputs["model_missing_loops"] is False
+
+
+def test_start_accepts_resolved_loops_off_prepare(
+    client: DeepOriginClient,
+    registered_protein: Protein,
+) -> None:
+    """Loops-off preparation can use the asynchronous interface."""
+    prep = ProteinPrep(
+        protein=registered_protein,
+        selection=_SAMPLE_SELECTION,
+        model_missing_loops=False,
+        client=client,
+    )
+
+    result = prep.start()
+
+    assert result is None
+    assert prep.id is not None
+    if client.env == "local":
+        assert is_success_status(prep.status)


### PR DESCRIPTION
## Summary

- Wrap `deeporigin.protein-prep` v2 in `ProteinPrep`: `action=recommend` then a digest-bound Selection and `action=prepare`.
- Add `SyncExecutableMixin` and blocking `run()` when the caller skips loop modelling (`as_prepare(model_missing_loops=False).run()`). `start()` stays valid for recommend and loops-on prepare; illegal `run()` raises.
- Docs, mock-server fixtures, and the protein-prep notebook follow the same two-step path.

**Jira:** [DDOS-7371](https://deeporigin.atlassian.net/browse/DDOS-7371)

## Test plan

- [ ] `uv run pytest --env local -x tests/test_protein_prep.py`
- [ ] Recommend with `ProteinPrep(protein).start()` then `get_recommendation()`
- [ ] Loops-off prepare: `as_prepare(model_missing_loops=False).run()` returns an in-memory `Protein`
- [ ] `run()` on recommend or loops-on prepare raises
- [ ] Loops-on prepare still works via `start()` / `wait()` / `get_results()`

[DDOS-7371]: https://deeporigin.atlassian.net/browse/DDOS-7371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ