### PR TITLE
feat(drug-discovery): add Protein.mark_as_prepared for PDB and CIF (DDOS-7519)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -171,6 +171,14 @@ by `ProteinPrep.get_results()`, whose structure is the cleaned PDB. Not a
 proteins-table row until the caller `sync()` or `update()`.
 _Avoid_: public `PreparedProtein` type; PreparedSystem
 
+**Prepared Protein stamp**:
+File-borne token that marks a structure as already prepared so downstream tools
+skip AUTO protein cleanup. PDB: `REMARK  99 DO_PREPARED`. mmCIF:
+`_deeporigin.prepared     DO_PREPARED`. Written by Protein Prep or
+`Protein.mark_as_prepared()`; never a public `PreparedProtein` type.
+_Avoid_: treating accidental PDB REMARK text inside CIF as prepared; converting
+CIF to PDB just to stamp
+
 **Protein**:
 A macromolecular target structure. Once synced, a platform proteins-table row.
 _Avoid_: PreparedSystem; Prepared protein (CLI) when you mean a catalog protein

--- a/docs/dd/how-to/proteins.md
+++ b/docs/dd/how-to/proteins.md
@@ -511,6 +511,21 @@ protein.to_cif("prepared_protein.cif")
 `Protein.show()` also falls back to mmCIF automatically when dumping state for the
 viewer, so visualization still works for those structures.
 
+### Marking a protein as prepared
+
+If you prepared the structure outside Deep Origin, stamp the local file so
+downstream tools skip automatic protein cleanup. See
+[Prepared Protein stamp](../ref/prepared_protein_stamp.md).
+
+```{.python notest}
+protein = Protein.from_file("my_prepared.pdb")  # or .cif
+protein.mark_as_prepared()
+protein.sync()
+```
+
+This does not run Protein Prep — it only writes the file-borne stamp in the
+file's native format (no CIF↔PDB conversion).
+
 !!! note "Platform proteins without a local file"
     If the protein was loaded with `from_id(..., download=False)`, it has `remote_path`
     but no local file yet. Call `download(client=...)` before `to_pdb()` or `to_file()`,

--- a/docs/dd/ref/prepared_protein_stamp.md
+++ b/docs/dd/ref/prepared_protein_stamp.md
@@ -1,12 +1,42 @@
 # Prepared Protein stamp
 
-Helpers that detect and preserve the file-borne Prepared Protein stamp
-(`REMARK  99 DO_PREPARED`) on PDB files.
+Helpers that detect and preserve the file-borne Prepared Protein stamp on
+structure files.
 
-Protein Prep writes this stamp onto the prepared PDB before upload. Downstream
-tools (Pocket Finder, Docking, System Prep) skip automatic protein cleanup when
-the stamp is present. The CLI must not drop it when rewriting or syncing a
-protein that already points at a stamped remote file.
+| Format | Stamp |
+|--------|--------|
+| PDB | `REMARK  99 DO_PREPARED` |
+| mmCIF | `_deeporigin.prepared     DO_PREPARED` |
+
+Protein Prep writes this stamp onto the prepared structure before upload.
+Downstream tools (Pocket Finder, Docking, System Prep) skip automatic protein
+cleanup when the stamp is present. The CLI must not drop it when rewriting or
+syncing a protein that already points at a stamped remote file.
+
+## Marking a protein as prepared
+
+If you prepare a protein outside Deep Origin and want downstream tools to treat
+it as already prepared, stamp the on-disk file with
+[`Protein.mark_as_prepared()`](protein.md):
+
+```{.python notest}
+from deeporigin.drug_discovery import Protein
+
+protein = Protein.from_file("my_prepared.cif")  # or .pdb
+protein.mark_as_prepared()  # mutates the local file in its native format
+protein.sync()              # uploads the stamped bytes to UFA
+```
+
+`mark_as_prepared()` never converts CIF to PDB (or vice versa). Prefer platform
+[Protein Prep](../tools/proteinprep.md) when you want Deep Origin to prepare the
+structure for you.
+
+Client `to_pdb()` / `to_cif()` translate the stamp across formats when the
+source was stamped. External converters (for example PyMOL “save as”) may still
+drop it — re-run `mark_as_prepared()` on the saved file if needed.
+
+Toolbox AUTO cleanup for stamped mmCIF is rolled out separately; stamped PDBs
+are already honoured.
 
 ::: src.drug_discovery.structures.prepared_protein_stamp
     options:

--- a/docs/dd/tools/proteinprep.md
+++ b/docs/dd/tools/proteinprep.md
@@ -64,7 +64,8 @@ platform protein ID until you call `sync()` or `update()`. The original input
 protein is unchanged. The prepared PDB carries a
 [`REMARK  99 DO_PREPARED`](../ref/prepared_protein_stamp.md) stamp; pass that
 `Protein` into Pocket Finder or other tools without re-serializing the file so
-the stamp stays intact.
+the stamp stays intact. To stamp a structure you prepared outside Deep Origin
+(PDB or mmCIF), use [`Protein.mark_as_prepared()`](../ref/prepared_protein_stamp.md).
 
 Loops-off preparation may also run asynchronously:
 

--- a/docs/notebooks/clean/mark-as-prepared.ipynb
+++ b/docs/notebooks/clean/mark-as-prepared.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Mark a protein as prepared\n",
+    "\n",
+    "Stamp a local PDB or mmCIF so downstream tools treat it as already prepared.\n",
+    "`mark_as_prepared()` mutates the on-disk file in its native format (no CIF→PDB conversion).\n",
+    "Call `sync()` separately to upload the stamped bytes to UFA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "autoreload",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "stamp-pdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import tempfile\n",
+    "\n",
+    "from deeporigin.drug_discovery import Protein\n",
+    "from deeporigin.drug_discovery.structures.prepared_protein_stamp import (\n",
+    "    has_prepared_protein_stamp,\n",
+    ")\n",
+    "from deeporigin.utils.constants import PREPARED_PROTEIN_CIF_STAMP_LINE\n",
+    "\n",
+    "workdir = Path(tempfile.mkdtemp(prefix=\"mark-prepared-\"))\n",
+    "pdb_path = workdir / \"ala.pdb\"\n",
+    "pdb_path.write_text(\n",
+    "    \"ATOM      1  N   ALA A   1      11.104  13.207   9.068  1.00  0.00           N\\n\"\n",
+    "    \"END\\n\"\n",
+    ")\n",
+    "\n",
+    "protein = Protein.from_file(pdb_path)\n",
+    "protein.mark_as_prepared()\n",
+    "assert has_prepared_protein_stamp(pdb_path)\n",
+    "print(\"Stamped PDB:\", pdb_path.read_text().splitlines()[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "stamp-cif",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cif_src = Path(\"tests/fixtures/1EBY.cif\")\n",
+    "cif_path = workdir / \"1eby.cif\"\n",
+    "cif_path.write_text(cif_src.read_text())\n",
+    "\n",
+    "protein_cif = Protein.from_file(cif_path)\n",
+    "protein_cif.mark_as_prepared()\n",
+    "assert has_prepared_protein_stamp(cif_path)\n",
+    "assert PREPARED_PROTEIN_CIF_STAMP_LINE in cif_path.read_text()\n",
+    "print(\"CIF remains .cif:\", cif_path.suffix)\n",
+    "print(\"Stamp line present:\", PREPARED_PROTEIN_CIF_STAMP_LINE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sync-note",
+   "metadata": {},
+   "source": [
+    "To push stamped bytes to the platform (overwriting an existing UFA object when\n",
+    "`remote_path` is set), call `protein.sync()` after marking. That upload uses the\n",
+    "local file bytes and does not convert CIF to PDB."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/drug_discovery/structures/prepared_protein_stamp.py
+++ b/src/drug_discovery/structures/prepared_protein_stamp.py
@@ -1,17 +1,29 @@
-"""Prepared Protein stamp: file-borne REMARK 99 DO_PREPARED token.
+"""Prepared Protein stamp: file-borne DO_PREPARED token for PDB and mmCIF.
 
 Mirrors the platform-toolbox stamp helper so the CLI can detect and preserve
 the stamp without depending on ``toolbox_core``. Downstream Pocket Finder,
 Docking, and System Prep skip AUTO protein cleanup when the token is present.
+
+PDB uses ``REMARK  99 DO_PREPARED``. mmCIF uses
+``_deeporigin.prepared     DO_PREPARED`` (a private data item — not a PDB
+REMARK line embedded in CIF text).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from deeporigin.utils.constants import PREPARED_PROTEIN_STAMP_LINE
+from deeporigin.utils.constants import (
+    PREPARED_PROTEIN_CIF_STAMP_KEY,
+    PREPARED_PROTEIN_CIF_STAMP_LINE,
+    PREPARED_PROTEIN_CIF_STAMP_VALUE,
+    PREPARED_PROTEIN_STAMP_LINE,
+)
 
 _STAMP_BYTES = (PREPARED_PROTEIN_STAMP_LINE + "\n").encode("ascii")
+
+_CIF_SUFFIXES = frozenset({".cif", ".mmcif"})
+_PDB_SUFFIXES = frozenset({".pdb", ".pdbqt"})
 
 
 def text_has_prepared_protein_stamp(text: str) -> bool:
@@ -19,6 +31,10 @@ def text_has_prepared_protein_stamp(text: str) -> bool:
 
     Whitespace around the remark number is lenient so a one-space rewrite still
     matches. The writer always emits the canonical two-space line.
+
+    This is PDB-only. Accidental REMARK text inside an mmCIF file must not be
+    treated as prepared — use :func:`text_has_prepared_protein_cif_stamp` for
+    CIF.
 
     Args:
         text: PDB file contents as text.
@@ -37,22 +53,73 @@ def text_has_prepared_protein_stamp(text: str) -> bool:
     return False
 
 
-def has_prepared_protein_stamp(path: str | Path) -> bool:
-    """Return True if a REMARK 99 DO_PREPARED token appears before ATOM/HETATM.
+def text_has_prepared_protein_cif_stamp(text: str) -> bool:
+    """Return True if the canonical mmCIF Prepared Protein stamp is present.
+
+    Matches ``_deeporigin.prepared`` with value ``DO_PREPARED``. Does not treat
+    PDB-style ``REMARK  99 DO_PREPARED`` text inside CIF as prepared.
 
     Args:
-        path: Local PDB path to inspect.
+        text: mmCIF file contents as text.
     """
-    text = Path(path).read_bytes().decode("latin-1")
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if (
+            len(parts) >= 2
+            and parts[0] == PREPARED_PROTEIN_CIF_STAMP_KEY
+            and parts[1].strip("\"'") == PREPARED_PROTEIN_CIF_STAMP_VALUE
+        ):
+            return True
+    return False
+
+
+def _is_cif_path(path: Path) -> bool:
+    """Return True if *path* should be treated as mmCIF by extension."""
+    return path.suffix.lower() in _CIF_SUFFIXES
+
+
+def _is_pdb_path(path: Path) -> bool:
+    """Return True if *path* should be treated as PDB by extension."""
+    return path.suffix.lower() in _PDB_SUFFIXES
+
+
+def _sniff_cif_text(text: str) -> bool:
+    """Return True if *text* looks like mmCIF (``data_`` header)."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return stripped.startswith("data_")
+    return False
+
+
+def has_prepared_protein_stamp(path: str | Path) -> bool:
+    """Return True if the file carries a Prepared Protein stamp for its format.
+
+    PDB/``.pdb`` files use the REMARK 99 token. CIF/``.cif`` / ``.mmcif`` files
+    use ``_deeporigin.prepared``. When the suffix is ambiguous, sniff the
+    contents (``data_`` ⇒ CIF, otherwise PDB).
+
+    Args:
+        path: Local structure file path to inspect.
+    """
+    file_path = Path(path)
+    text = file_path.read_bytes().decode("latin-1")
+    if _is_cif_path(file_path) or (
+        not _is_pdb_path(file_path) and _sniff_cif_text(text)
+    ):
+        return text_has_prepared_protein_cif_stamp(text)
     return text_has_prepared_protein_stamp(text)
 
 
 def stamp_prepared_protein_pdb(path: str | Path) -> None:
-    """Prepend the canonical Prepared Protein stamp if it is not already present.
+    """Prepend the canonical Prepared Protein PDB stamp if not already present.
 
     Uses a text prepend, not a structure rewrite, so ATOM/HETATM bytes are
-    unchanged. Idempotent when :func:`has_prepared_protein_stamp` is already
-    true.
+    unchanged. Idempotent when a PDB stamp is already present.
 
     Args:
         path: Local PDB path to stamp.
@@ -62,7 +129,75 @@ def stamp_prepared_protein_pdb(path: str | Path) -> None:
         FileNotFoundError: If *path* does not exist.
     """
     pdb_path = Path(path)
-    if has_prepared_protein_stamp(pdb_path):
+    text = pdb_path.read_bytes().decode("latin-1")
+    if text_has_prepared_protein_stamp(text):
         return
     body = pdb_path.read_bytes()
     pdb_path.write_bytes(_STAMP_BYTES + body)  # NOSONAR local path, not external input
+
+
+def stamp_prepared_protein_cif(path: str | Path) -> None:
+    """Insert the canonical mmCIF Prepared Protein stamp if not already present.
+
+    Inserts ``_deeporigin.prepared     DO_PREPARED`` immediately after the first
+    ``data_`` line when present, otherwise at the start of the file. Does not
+    rewrite atom sites. Idempotent when the CIF stamp is already present.
+
+    Args:
+        path: Local mmCIF path to stamp.
+
+    Raises:
+        OSError: If the file cannot be read or written.
+        FileNotFoundError: If *path* does not exist.
+    """
+    cif_path = Path(path)
+    raw = cif_path.read_bytes()
+    text = raw.decode("utf-8")
+    if text_has_prepared_protein_cif_stamp(text):
+        return
+
+    lines = text.splitlines(keepends=True)
+    insert_at = 0
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("data_"):
+            insert_at = index + 1
+            break
+
+    stamp_line = PREPARED_PROTEIN_CIF_STAMP_LINE + "\n"
+    lines.insert(insert_at, stamp_line)
+    cif_path.write_bytes("".join(lines).encode("utf-8"))  # NOSONAR local path
+
+
+def stamp_prepared_protein(path: str | Path) -> None:
+    """Stamp a structure file in its native format (PDB or mmCIF).
+
+    Dispatches on file extension (and content sniff when needed). Never
+    converts CIF to PDB or vice versa.
+
+    Args:
+        path: Local PDB or mmCIF path to stamp.
+
+    Raises:
+        OSError: If the file cannot be read or written.
+        FileNotFoundError: If *path* does not exist.
+        ValueError: If the format cannot be determined.
+    """
+    file_path = Path(path)
+    if _is_cif_path(file_path):
+        stamp_prepared_protein_cif(file_path)
+        return
+    if _is_pdb_path(file_path):
+        stamp_prepared_protein_pdb(file_path)
+        return
+
+    text = file_path.read_bytes().decode("latin-1")
+    if _sniff_cif_text(text):
+        stamp_prepared_protein_cif(file_path)
+        return
+    if text.lstrip().startswith(("HEADER", "TITLE", "REMARK", "ATOM", "HETATM")):
+        stamp_prepared_protein_pdb(file_path)
+        return
+    raise ValueError(
+        f"Cannot determine structure format for {file_path}; "
+        "expected a .pdb / .cif / .mmcif file."
+    )

--- a/src/drug_discovery/structures/protein.py
+++ b/src/drug_discovery/structures/protein.py
@@ -38,7 +38,10 @@ from .pocket import Pocket
 from .pose import Pose, PoseSet
 from .prepared_protein_stamp import (
     has_prepared_protein_stamp,
+    stamp_prepared_protein,
+    stamp_prepared_protein_cif,
     stamp_prepared_protein_pdb,
+    text_has_prepared_protein_cif_stamp,
     text_has_prepared_protein_stamp,
 )
 
@@ -1169,6 +1172,52 @@ class Protein(Entity):
             return False
         return True
 
+    def _source_has_prepared_stamp(self) -> bool:
+        """Return True if the on-disk or in-memory source carries a prepared stamp."""
+        if self.local_path is not None and Path(self.local_path).is_file():
+            return has_prepared_protein_stamp(self.local_path)
+        if isinstance(self.block_content, str) and self.block_content:
+            return text_has_prepared_protein_stamp(
+                self.block_content
+            ) or text_has_prepared_protein_cif_stamp(self.block_content)
+        return False
+
+    def mark_as_prepared(self) -> Self:
+        """Stamp the on-disk protein file as a Prepared Protein.
+
+        Writes the canonical Prepared Protein token onto :attr:`local_path` in
+        the file's native format (PDB ``REMARK  99 DO_PREPARED`` or mmCIF
+        ``_deeporigin.prepared     DO_PREPARED``). Does **not** convert CIF to
+        PDB or vice versa. Does not upload; call :meth:`sync` afterward to push
+        the stamped bytes to UFA.
+
+        Idempotent when the file is already stamped. Requires a readable
+        :attr:`local_path` (for example after :meth:`from_file` or
+        :meth:`download`).
+
+        Returns:
+            Self, for chaining.
+
+        Raises:
+            DeepOriginException: If :attr:`local_path` is unset or not a file.
+        """
+        if self.local_path is None or not Path(self.local_path).is_file():
+            raise DeepOriginException(
+                title="No local protein file to stamp",
+                message=(
+                    "mark_as_prepared() requires a readable local_path. "
+                    "Load with Protein.from_file(...) or call download() first."
+                ),
+            )
+
+        stamp_prepared_protein(self.local_path)
+        # Keep in-memory block in sync with the stamped on-disk bytes.
+        try:
+            self.block_content = Path(self.local_path).read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            self.block_content = Path(self.local_path).read_text(encoding="latin-1")
+        return self
+
     @beartype
     def to_pdb(self, file_path: Optional[str | Path] = None) -> str:
         """
@@ -1178,9 +1227,10 @@ class Protein(Entity):
         protein has :attr:`remote_path` but no local file yet, raise; rehydrate with
         :meth:`download` first.
 
-        When the source PDB (:attr:`local_path` or :attr:`block_content`) carries a
-        Prepared Protein stamp (``REMARK  99 DO_PREPARED``), the stamp is
-        re-prepended after the biotite rewrite so the token is never dropped.
+        When the source structure file (:attr:`local_path` or :attr:`block_content`)
+        carries a Prepared Protein stamp (PDB REMARK or mmCIF
+        ``_deeporigin.prepared``), the PDB stamp is re-prepended after the biotite
+        rewrite so the token is never dropped (including CIF→PDB translation).
 
         Args:
             file_path (str): Path where the PDB file will be written.
@@ -1204,11 +1254,7 @@ class Protein(Entity):
                 ),
             )
 
-        source_has_stamp = False
-        if self.local_path is not None and Path(self.local_path).is_file():
-            source_has_stamp = has_prepared_protein_stamp(self.local_path)
-        elif isinstance(self.block_content, str) and self.block_content:
-            source_has_stamp = text_has_prepared_protein_stamp(self.block_content)
+        source_has_stamp = self._source_has_prepared_stamp()
 
         if file_path is None:
             file_path = PROTEINS_DIR / (self.to_hash() + ".pdb")
@@ -1236,6 +1282,11 @@ class Protein(Entity):
         operation on :attr:`structure`; rehydrate with :meth:`download` first if
         only :attr:`remote_path` is set.
 
+        When the source carries a Prepared Protein stamp (PDB or mmCIF), the
+        mmCIF stamp is written after the biotite rewrite so the token is
+        preserved (including PDB→CIF translation). External converters that
+        do not go through this method may still drop the stamp.
+
         Args:
             file_path: Path where the CIF file will be written. If ``None``, uses
                 a default path under the proteins cache directory.
@@ -1261,6 +1312,8 @@ class Protein(Entity):
                 ),
             )
 
+        source_has_stamp = self._source_has_prepared_stamp()
+
         if file_path is None:
             file_path = PROTEINS_DIR / (self.to_hash() + ".cif")
 
@@ -1270,6 +1323,8 @@ class Protein(Entity):
             cif_file = pdbx.CIFFile()
             pdbx.set_structure(cif_file, self.structure)
             cif_file.write(str(file_path))
+            if source_has_stamp:
+                stamp_prepared_protein_cif(file_path)
             return str(file_path)
         except Exception as e:
             raise RuntimeError(
@@ -1587,6 +1642,58 @@ class Protein(Entity):
             info_str += f"Info: {self.info}\n"
         return f"Protein:\n  {info_str}"
 
+    def upload(
+        self,
+        *,
+        client: Optional[DeepOriginClient] = None,
+        remote_path: Optional[str] = None,
+    ) -> None:
+        """Upload the protein file to remote storage.
+
+        When :attr:`local_path` points to an existing file, uploads those bytes
+        as-is (preserving PDB vs CIF and any Prepared Protein stamp). Does not
+        rewrite through :meth:`to_file` / :meth:`to_pdb` on that path. When no
+        local file exists, falls back to :meth:`Entity.upload` (serialize via
+        :meth:`to_file`).
+
+        Args:
+            client: DeepOriginClient instance. If None, uses DeepOriginClient().
+            remote_path: Destination remote path. When provided, sets
+                :attr:`remote_path` before uploading. If still unset, uses a
+                hash-based path whose extension matches the local file when
+                present.
+        """
+        if client is None:
+            client = DeepOriginClient()
+
+        if remote_path is not None:
+            self.remote_path = remote_path
+
+        if self.local_path is not None and Path(self.local_path).is_file():
+            local_file = str(self.local_path)
+            if self.remote_path is None:
+                ext = Path(local_file).suffix or self._preferred_ext
+                self.remote_path = f"{self._remote_path_base}{self.to_hash()}{ext}"
+            client.files.upload(
+                local_file,
+                remote_path=self.remote_path,
+            )
+            return
+
+        super().upload(client=client, remote_path=remote_path)
+
+    def _should_upload_local_bytes(self, *, remote_path: Optional[str]) -> bool:
+        """Return True when sync/register should upload from :attr:`local_path`.
+
+        Uploads when an explicit ``remote_path`` is passed, when no remote path
+        is set yet, or when a local file exists (so stamped bytes overwrite UFA).
+        """
+        if remote_path is not None:
+            return True
+        if self.local_path is not None and Path(self.local_path).is_file():
+            return True
+        return self.remote_path is None
+
     @beartype
     def register(
         self,
@@ -1598,9 +1705,9 @@ class Protein(Entity):
 
         Uploads the protein file when needed, then creates a new protein
         record, regardless of whether one already exists for this file path.
-        When :attr:`remote_path` is already set and ``remote_path`` is not
-        passed, skips upload so an existing UFA object (e.g. a Prepared
-        Protein with ``REMARK  99 DO_PREPARED``) is not overwritten.
+        When :attr:`local_path` is a readable file, uploads those bytes (create
+        or overwrite :attr:`remote_path`) without a biotite rewrite. When there
+        is no local file and :attr:`remote_path` is already set, skips upload.
 
         Args:
             client: DeepOriginClient instance. If None, uses DeepOriginClient().
@@ -1614,7 +1721,7 @@ class Protein(Entity):
         if client is None:
             client = DeepOriginClient()
 
-        if remote_path is not None or self.remote_path is None:
+        if self._should_upload_local_bytes(remote_path=remote_path):
             self.upload(client=client, remote_path=remote_path)
 
         kwargs: dict[str, Any] = {
@@ -1652,10 +1759,10 @@ class Protein(Entity):
         one with the same file path already exists, otherwise creates a new
         record via :meth:`register`.
 
-        When :attr:`remote_path` is already set and ``remote_path`` is not
-        passed, skips upload so an existing UFA object (e.g. a Prepared Protein
-        stamped with ``REMARK  99 DO_PREPARED``) is not overwritten by a
-        biotite rewrite.
+        When :attr:`local_path` is a readable file, always uploads those bytes
+        to :attr:`remote_path` (creating or overwriting the UFA object) without
+        converting CIF→PDB. When there is no local file and
+        :attr:`remote_path` is already set, skips upload.
 
         Args:
             lazy: If True, skip syncing when the protein already has an ID.
@@ -1681,7 +1788,7 @@ class Protein(Entity):
         if client is None:
             client = DeepOriginClient()
 
-        if remote_path is not None or self.remote_path is None:
+        if self._should_upload_local_bytes(remote_path=remote_path):
             self.upload(client=client, remote_path=remote_path)
 
         proj_id = self.resolved_project_id(client=client)

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -110,6 +110,15 @@ PREPARED_PROTEIN_STAMP_LINE = "REMARK  99 DO_PREPARED"
 Written by Protein Prep before UFA upload. Downstream tools skip AUTO protein
 cleanup when this token is present. CLI writers must preserve it."""
 
+PREPARED_PROTEIN_CIF_STAMP_KEY = "_deeporigin.prepared"
+"""mmCIF data item name for the Prepared Protein stamp."""
+
+PREPARED_PROTEIN_CIF_STAMP_VALUE = "DO_PREPARED"
+"""Value of :data:`PREPARED_PROTEIN_CIF_STAMP_KEY` (same token as the PDB remark)."""
+
+PREPARED_PROTEIN_CIF_STAMP_LINE = "_deeporigin.prepared     DO_PREPARED"
+"""Canonical mmCIF line marking a Prepared Protein (file-borne stamp)."""
+
 PROTEIN_PREP_PDB_ID_PATTERN = r"^[A-Za-z0-9]{4}$"
 """JSON Schema pattern for Protein Prep ``pdb_id`` (loop-modelling templates)."""
 

--- a/tests/test_prepared_protein_stamp.py
+++ b/tests/test_prepared_protein_stamp.py
@@ -5,18 +5,35 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from deeporigin.drug_discovery.structures.prepared_protein_stamp import (
     has_prepared_protein_stamp,
+    stamp_prepared_protein,
+    stamp_prepared_protein_cif,
     stamp_prepared_protein_pdb,
+    text_has_prepared_protein_cif_stamp,
     text_has_prepared_protein_stamp,
 )
 from deeporigin.drug_discovery.structures.protein import Protein
-from deeporigin.utils.constants import PREPARED_PROTEIN_STAMP_LINE
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.utils.constants import (
+    PREPARED_PROTEIN_CIF_STAMP_LINE,
+    PREPARED_PROTEIN_STAMP_LINE,
+)
 
 _MINIMAL_ATOM = (
     "ATOM      1  N   ALA A   1      11.104  13.207   9.068  1.00  0.00           N\n"
     "END\n"
 )
+
+_MINIMAL_CIF = """data_test
+#
+_atom_site.id 1
+#
+"""
+
+_FIXTURE_CIF = Path(__file__).parent / "fixtures" / "1EBY.cif"
 
 
 def test_text_has_prepared_protein_stamp_detects_canonical_line() -> None:
@@ -57,6 +74,44 @@ def test_stamp_prepared_protein_pdb_is_idempotent(tmp_path: Path) -> None:
     assert pdb_path.read_text().startswith(PREPARED_PROTEIN_STAMP_LINE + "\n")
 
 
+def test_stamp_prepared_protein_cif_is_idempotent(tmp_path: Path) -> None:
+    """stamp_prepared_protein_cif inserts once and is a no-op thereafter."""
+    cif_path = tmp_path / "protein.cif"
+    cif_path.write_text(_MINIMAL_CIF)
+    assert has_prepared_protein_stamp(cif_path) is False
+
+    stamp_prepared_protein_cif(cif_path)
+    assert has_prepared_protein_stamp(cif_path) is True
+    first = cif_path.read_bytes()
+    assert PREPARED_PROTEIN_CIF_STAMP_LINE in cif_path.read_text()
+
+    stamp_prepared_protein_cif(cif_path)
+    assert cif_path.read_bytes() == first
+
+
+def test_pdb_remark_text_inside_cif_is_not_prepared(tmp_path: Path) -> None:
+    """Accidental PDB REMARK text in a CIF file does not count as prepared."""
+    cif_path = tmp_path / "accidental.cif"
+    cif_path.write_text(f"data_test\n{PREPARED_PROTEIN_STAMP_LINE}\n_atom_site.id 1\n")
+    assert text_has_prepared_protein_stamp(cif_path.read_text()) is True
+    assert text_has_prepared_protein_cif_stamp(cif_path.read_text()) is False
+    assert has_prepared_protein_stamp(cif_path) is False
+
+
+def test_stamp_prepared_protein_dispatches_by_extension(tmp_path: Path) -> None:
+    """stamp_prepared_protein stamps PDB and CIF without converting formats."""
+    pdb_path = tmp_path / "a.pdb"
+    pdb_path.write_text(_MINIMAL_ATOM)
+    stamp_prepared_protein(pdb_path)
+    assert pdb_path.read_text().startswith(PREPARED_PROTEIN_STAMP_LINE)
+
+    cif_path = tmp_path / "b.cif"
+    cif_path.write_text(_MINIMAL_CIF)
+    stamp_prepared_protein(cif_path)
+    assert PREPARED_PROTEIN_CIF_STAMP_LINE in cif_path.read_text()
+    assert not cif_path.read_text().startswith("REMARK")
+
+
 def test_protein_to_pdb_preserves_do_prepared_stamp(tmp_path: Path) -> None:
     """biotite rewrite via to_pdb re-prepends DO_PREPARED when the source had it."""
     stamped = tmp_path / "stamped.pdb"
@@ -83,33 +138,88 @@ def test_protein_to_pdb_does_not_add_stamp_when_source_unstamped(
     assert has_prepared_protein_stamp(out) is False
 
 
+def test_protein_mark_as_prepared_stamps_pdb_in_place(tmp_path: Path) -> None:
+    """mark_as_prepared stamps a PDB local_path without changing extension."""
+    pdb_path = tmp_path / "protein.pdb"
+    pdb_path.write_text(_MINIMAL_ATOM)
+    protein = Protein.from_file(pdb_path)
+
+    result = protein.mark_as_prepared()
+    assert result is protein
+    assert has_prepared_protein_stamp(pdb_path) is True
+    assert pdb_path.suffix == ".pdb"
+    assert protein.local_path == str(pdb_path)
+
+
+def test_protein_mark_as_prepared_stamps_cif_without_pdb_conversion(
+    tmp_path: Path,
+) -> None:
+    """mark_as_prepared stamps CIF in place and never writes a PDB."""
+    cif_path = tmp_path / "protein.cif"
+    cif_path.write_text(_FIXTURE_CIF.read_text())
+    protein = Protein.from_file(cif_path)
+
+    protein.mark_as_prepared()
+    assert has_prepared_protein_stamp(cif_path) is True
+    assert cif_path.suffix == ".cif"
+    assert PREPARED_PROTEIN_CIF_STAMP_LINE in cif_path.read_text()
+    assert list(tmp_path.glob("*.pdb")) == []
+
+
+def test_protein_mark_as_prepared_requires_local_path() -> None:
+    """mark_as_prepared raises when there is no readable local_path."""
+    protein = Protein(name="no-file", structure=None, local_path=None)
+    with pytest.raises(DeepOriginException, match="local_path"):
+        protein.mark_as_prepared()
+
+
+def test_protein_to_cif_translates_pdb_stamp(tmp_path: Path) -> None:
+    """to_cif writes the mmCIF stamp when the PDB source was stamped."""
+    stamped = tmp_path / "stamped.pdb"
+    stamped.write_text(f"{PREPARED_PROTEIN_STAMP_LINE}\n{_MINIMAL_ATOM}")
+    protein = Protein.from_file(stamped)
+
+    out = tmp_path / "out.cif"
+    protein.to_cif(out)
+    assert has_prepared_protein_stamp(out) is True
+    assert text_has_prepared_protein_cif_stamp(out.read_text()) is True
+
+
+def test_protein_to_pdb_translates_cif_stamp(tmp_path: Path) -> None:
+    """to_pdb writes the PDB stamp when the CIF source was stamped."""
+    stamped = tmp_path / "stamped.cif"
+    stamped.write_text(_FIXTURE_CIF.read_text())
+    stamp_prepared_protein_cif(stamped)
+    protein = Protein.from_file(stamped)
+
+    out = tmp_path / "out.pdb"
+    protein.to_pdb(out)
+    assert has_prepared_protein_stamp(out) is True
+    assert out.read_text().startswith(PREPARED_PROTEIN_STAMP_LINE + "\n")
+
+
 def test_protein_sync_lazy_skips_upload_when_remote_path_set() -> None:
-    """sync(lazy=True) still resolves an id, but skips upload, when remote_path
-    is already populated and no id is set yet."""
+    """sync(lazy=True) with an existing id skips work entirely."""
     from deeporigin.platform.client import DeepOriginClient
 
     protein = Protein(
         name="prepared",
         structure=None,
+        id="prot-existing",
         remote_path="entities/proteins/prepared.pdb",
     )
     client = MagicMock(spec=DeepOriginClient)
     client.project_id = None
-    client.entities = MagicMock()
-    client.entities.search_proteins.return_value = {
-        "data": [{"id": "prot-existing", "project_id": None}]
-    }
 
     with patch.object(protein, "upload") as upload:
         protein.sync(lazy=True, client=client)
 
     upload.assert_not_called()
     assert protein.id == "prot-existing"
-    assert protein.remote_path == "entities/proteins/prepared.pdb"
 
 
 def test_protein_sync_skips_upload_but_registers_when_remote_path_only() -> None:
-    """Non-lazy sync with remote_path set skips upload and still registers."""
+    """Non-lazy sync with remote_path set and no local file skips upload."""
     from deeporigin.platform.client import DeepOriginClient
 
     protein = Protein(
@@ -157,3 +267,54 @@ def test_protein_sync_links_existing_without_upload_when_remote_path_set() -> No
     upload.assert_not_called()
     client.entities.create_protein.assert_not_called()
     assert protein.id == "prot-existing"
+
+
+def test_protein_sync_uploads_local_bytes_when_remote_path_set(
+    tmp_path: Path,
+) -> None:
+    """sync uploads stamped local file bytes even when remote_path is already set."""
+    from deeporigin.platform.client import DeepOriginClient
+
+    cif_path = tmp_path / "protein.cif"
+    cif_path.write_text(_FIXTURE_CIF.read_text())
+    protein = Protein.from_file(cif_path)
+    protein.mark_as_prepared()
+    protein.remote_path = "entities/proteins/existing.cif"
+
+    client = MagicMock(spec=DeepOriginClient)
+    client.project_id = None
+    client.files = MagicMock()
+    client.entities = MagicMock()
+    client.entities.search_proteins.return_value = {
+        "data": [{"id": "prot-existing", "project_id": None}],
+    }
+
+    protein.sync(lazy=False, client=client)
+
+    client.files.upload.assert_called_once()
+    uploaded_path = client.files.upload.call_args.args[0]
+    kwargs = client.files.upload.call_args.kwargs
+    assert Path(uploaded_path) == cif_path
+    assert kwargs["remote_path"] == "entities/proteins/existing.cif"
+    assert protein.id == "prot-existing"
+
+
+def test_protein_upload_uses_local_bytes_not_to_file(tmp_path: Path) -> None:
+    """Protein.upload sends local CIF bytes and does not serialize via to_file."""
+    from deeporigin.platform.client import DeepOriginClient
+
+    cif_path = tmp_path / "protein.cif"
+    cif_path.write_text(_FIXTURE_CIF.read_text())
+    protein = Protein.from_file(cif_path)
+    protein.mark_as_prepared()
+
+    client = MagicMock(spec=DeepOriginClient)
+    client.files = MagicMock()
+
+    with patch.object(protein, "to_file") as to_file:
+        protein.upload(client=client)
+
+    to_file.assert_not_called()
+    client.files.upload.assert_called_once()
+    assert Path(client.files.upload.call_args.args[0]) == cif_path
+    assert str(protein.remote_path).endswith(".cif")


### PR DESCRIPTION
## Summary

- Add `Protein.mark_as_prepared()` to stamp on-disk PDB (`REMARK  99 DO_PREPARED`) or mmCIF (`_deeporigin.prepared     DO_PREPARED`) in native format with no CIF↔PDB conversion
- Translate stamps on client `to_pdb` / `to_cif`; sync/upload push local file bytes (overwrite `remote_path` when set) without biotite rewrite
- Docs, glossary, and demo notebook for the off-platform prep workflow

**Jira:** [DDOS-7519](https://deeporigin.atlassian.net/browse/DDOS-7519)

## Test plan

- [x] `uv run pytest tests/test_prepared_protein_stamp.py --env local` (20 tests)
- [ ] Spot-check notebook cells in `docs/notebooks/clean/mark-as-prepared.ipynb`
- [ ] Confirm CIF stamp is ignored by toolbox AUTO until DDOS-7520 (expected)

[DDOS-7519]: https://deeporigin.atlassian.net/browse/DDOS-7519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ