### PR TITLE
feat(drug-discovery): add StructureReport client (DDOS-7377)

### DIFF
--- a/docs/dd/ref/structure_report.md
+++ b/docs/dd/ref/structure_report.md
@@ -1,0 +1,17 @@
+# `deeporigin.drug_discovery.structure_report`
+
+::: src.drug_discovery.structure_report.StructureReport
+    options:
+      docstring_style: google
+      show_root_heading: false
+      show_category_heading: true
+      show_object_full_path: false
+      show_root_toc_entry: false
+      inherited_members: true
+      members_order: alphabetical
+      filters:
+        - "!^_"  # Exclude private members (names starting with "_")
+      show_signature: true
+      show_signature_annotations: true
+      show_if_no_docstring: true
+      group_by_category: true

--- a/docs/dd/ref/structure_report_result.md
+++ b/docs/dd/ref/structure_report_result.md
@@ -1,0 +1,21 @@
+# `deeporigin.drug_discovery.structure_report.StructureReportResult`
+
+`StructureReportResult` holds one graded row from a
+[`StructureReport`](structure_report.md) `run()`: metadata fields, component
+scores, weighted score, and letter grade as returned by the platform tool.
+
+::: src.drug_discovery.structure_report.StructureReportResult
+    options:
+      docstring_style: google
+      show_root_heading: false
+      show_category_heading: true
+      show_object_full_path: false
+      show_root_toc_entry: false
+      inherited_members: true
+      members_order: alphabetical
+      filters:
+        - "!^_"  # Exclude private members (names starting with "_")
+      show_signature: true
+      show_signature_annotations: true
+      show_if_no_docstring: true
+      group_by_category: true

--- a/docs/dd/tools/structure-report.md
+++ b/docs/dd/tools/structure-report.md
@@ -1,0 +1,68 @@
+# Structure Report
+
+Grade a protein structure for target preparation. Provide a local
+[`Protein`](../ref/protein.md) file, a four-character
+[Protein Data Bank (PDB) :octicons-link-external-16:](https://www.rcsb.org/)
+ID, or both. Call `run()` to get letter grades and component scores from the
+platform — the client does not recompute grades.
+
+You must be logged in (`deeporigin login`) before calling `run()`. The call
+blocks until the job finishes.
+
+## Local structure
+
+Upload or sync a `Protein`, then grade it. Passing `pdb_id` alongside the
+protein tells the tool to use the PDB entry for experimental metadata
+(organism, method, resolution, Rfree, ligand) while coverage still comes from
+your coordinates:
+
+```{.python notest}
+from deeporigin.drug_discovery import Protein, StructureReport
+
+protein = Protein.from_file("my_target.pdb")
+protein.sync()
+
+rows = StructureReport(protein=protein, pdb_id="1ABC").run()
+row = rows[0]
+row.grade, row.weighted_score, row.resolution
+```
+
+## Remote PDB ID only
+
+When you only have a PDB ID and do not need to upload coordinates, pass
+`pdb_id` alone. The tool scores from RCSB metadata (no structure file):
+
+```{.python notest}
+from deeporigin.drug_discovery import StructureReport
+
+rows = StructureReport(pdb_id="1ABC").run()
+rows[0].grade, rows[0].metadata_source
+```
+
+## Quote cost
+
+Structure Report billing may be skipped on the platform, but the usual quote
+pattern still works:
+
+```{.python notest}
+job = StructureReport(pdb_id="1ABC")
+job.run(quote=True)
+job.estimate
+```
+
+## Working with a past run
+
+Reconnect by execution id (or use `from_last_run()`), then use the inherited
+`get_results()` to load indexed rows from the data platform:
+
+```{.python notest}
+from deeporigin.drug_discovery import StructureReport
+
+job = StructureReport.from_id("<executionId>")
+job.sync()
+job.get_results()
+```
+
+See also the API reference for
+[`StructureReport`](../ref/structure_report.md) and
+[`StructureReportResult`](../ref/structure_report_result.md).

--- a/docs/notebooks/clean/structure-report.ipynb
+++ b/docs/notebooks/clean/structure-report.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b380fae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6936422b",
+   "metadata": {},
+   "source": [
+    "# Structure Report\n",
+    "\n",
+    "Grade a protein structure with `StructureReport`. Provide a local `Protein`, a four-character PDB ID, or both. `run()` blocks until the platform returns graded rows.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e64d934",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from deeporigin.drug_discovery import Protein, StructureReport\n",
+    "from deeporigin.platform import DeepOriginClient\n",
+    "\n",
+    "client = DeepOriginClient.from_disk()\n",
+    "client\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19daa46f",
+   "metadata": {},
+   "source": [
+    "## Remote PDB ID only\n",
+    "\n",
+    "No coordinate upload — the tool scores from RCSB metadata.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce75655a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote = StructureReport(pdb_id=\"1CRN\", client=client)\n",
+    "remote_rows = remote.run()\n",
+    "remote_rows[0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29489bfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = remote_rows[0]\n",
+    "row.grade, row.weighted_score, row.metadata_source, row.pdb_id\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34c5c27f",
+   "metadata": {},
+   "source": [
+    "## Local protein (+ optional PDB ID)\n",
+    "\n",
+    "Sync a local structure, then grade it. Passing `pdb_id` uses RCSB as authority for experimental metadata.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c044e48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protein = Protein.from_pdb_id(\"1CRN\")\n",
+    "protein.sync(client=client)\n",
+    "local = StructureReport(protein=protein, pdb_id=\"1CRN\", client=client)\n",
+    "local_rows = local.run()\n",
+    "local_rows[0].grade, local_rows[0].metadata_source, local_rows[0].source_sha256 is not None\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/drug_discovery/__init__.py
+++ b/src/drug_discovery/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
     "Enumerator",
     "ProteinPrep",
     "RecommendationView",
+    "StructureReport",
+    "StructureReportResult",
 ]
 
 DATA_DIR = files("deeporigin.data")
@@ -76,6 +78,14 @@ _LAZY_IMPORTS = {
     "RecommendationView": (
         "deeporigin.drug_discovery.protein_prep",
         "RecommendationView",
+    ),
+    "StructureReport": (
+        "deeporigin.drug_discovery.structure_report",
+        "StructureReport",
+    ),
+    "StructureReportResult": (
+        "deeporigin.drug_discovery.structure_report",
+        "StructureReportResult",
     ),
     "Execution": ("deeporigin.drug_discovery.execution", "Execution"),
     "PlatformStatus": ("deeporigin.platform.constants", "PlatformStatus"),

--- a/src/drug_discovery/structure_report.py
+++ b/src/drug_discovery/structure_report.py
@@ -1,0 +1,422 @@
+"""StructureReport -- grade a protein structure (served, sync-only).
+
+Backed by the platform tool ``deeporigin.structure-report``. Configure one
+:class:`StructureReport` with a :class:`~deeporigin.drug_discovery.structures.protein.Protein`
+and/or a four-character PDB ID, then call :meth:`run`. The tool returns graded
+rows under ``jobOutputs.structure_reports``; :meth:`run` maps those rows to
+:class:`StructureReportResult` instances. Do not recompute grades in the client.
+
+Indexed result-explorer rows remain available via the inherited
+:meth:`~deeporigin.drug_discovery.execution.Execution.get_results`.
+
+Usage::
+
+    from deeporigin.drug_discovery import Protein, StructureReport
+
+    # Local structure (optionally with PDB ID for RCSB metadata authority):
+    protein = Protein.from_pdb_id("1ABC")
+    rows = StructureReport(protein=protein, pdb_id="1ABC").run()
+
+    # Remote PDB ID only (no coordinate file upload):
+    rows = StructureReport(pdb_id="1ABC").run()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Literal, Self
+
+from beartype import beartype
+
+from deeporigin.drug_discovery.execution import Execution
+from deeporigin.drug_discovery.execution_mixins import SyncExecutableMixin
+from deeporigin.drug_discovery.protein_prep import _protein_tool_input
+from deeporigin.drug_discovery.structures.protein import Protein
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.platform.client import DeepOriginClient
+from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
+
+StructureReportGrade = Literal["A", "B", "C", "D"]
+MetadataSource = Literal["rcsb", "file_header", "file_header+rcsb"]
+FieldStatusValue = Literal["value", "not_applicable", "unknown"]
+
+_PDB_ID_RE = re.compile(r"^[A-Za-z0-9]{4}$")
+
+_REQUIRED_RESULT_KEYS = (
+    "metadata_source",
+    "field_status",
+    "resolution_score",
+    "coverage_score",
+    "rfree_score",
+    "inhibitor_score",
+    "method_score",
+    "organism_score",
+    "weighted_score",
+    "grade",
+)
+
+
+@dataclass(frozen=True)
+class StructureReportResult:
+    """One graded Structure Report row from ``jobOutputs.structure_reports``.
+
+    Attributes:
+        metadata_source: Provenance of experimental metadata used for scoring.
+        field_status: Per-field status map (``value``, ``not_applicable``, or
+            ``unknown``).
+        resolution_score: Resolution component score.
+        coverage_score: Coverage component score.
+        rfree_score: Rfree component score.
+        inhibitor_score: Inhibitor/holo component score.
+        method_score: Method component score.
+        organism_score: Organism component score.
+        weighted_score: Weighted Structure Report score from the tool.
+        grade: Letter grade ``A``–``D`` from the tool.
+        coverage: Polymer residue coverage fraction (0–1), if known.
+        has_ligand: Whether a non-water, non-ion ligand is present.
+        method: Experimental method string.
+        method_class: Normalized method class.
+        organism: Source organism scientific name.
+        organism_class: Normalized organism class.
+        pdb_id: PDB ID used for experimental metadata.
+        protein_id: Platform protein entity id when provided.
+        resolution: Structure resolution in Angstroms.
+        rfree: Rfree (X-ray).
+        source_sha256: SHA-256 of uploaded structure bytes (omitted in remote
+            PDB-ID-only mode).
+    """
+
+    metadata_source: MetadataSource
+    field_status: dict[str, FieldStatusValue]
+    resolution_score: float
+    coverage_score: float
+    rfree_score: float
+    inhibitor_score: float
+    method_score: float
+    organism_score: float
+    weighted_score: float
+    grade: StructureReportGrade
+    coverage: float | None = None
+    has_ligand: bool | None = None
+    method: str | None = None
+    method_class: str | None = None
+    organism: str | None = None
+    organism_class: str | None = None
+    pdb_id: str | None = None
+    protein_id: str | None = None
+    resolution: float | None = None
+    rfree: float | None = None
+    source_sha256: str | None = None
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> StructureReportResult:
+        """Build a result from one ``structure_reports[]`` object.
+
+        Args:
+            data: Raw row from ``jobOutputs.structure_reports``.
+
+        Returns:
+            A :class:`StructureReportResult` with tool fields populated.
+
+        Raises:
+            DeepOriginException: If required fields are missing or mistyped.
+        """
+        missing = [key for key in _REQUIRED_RESULT_KEYS if key not in data]
+        if missing:
+            raise DeepOriginException(
+                title="Invalid Structure Report row",
+                message=f"Missing required fields: {missing!r}.",
+            ) from None
+
+        field_status = data["field_status"]
+        if not isinstance(field_status, dict):
+            raise DeepOriginException(
+                title="Invalid Structure Report row",
+                message="Expected field_status to be a dict.",
+            ) from None
+
+        return cls(
+            metadata_source=data["metadata_source"],
+            field_status=dict(field_status),
+            resolution_score=float(data["resolution_score"]),
+            coverage_score=float(data["coverage_score"]),
+            rfree_score=float(data["rfree_score"]),
+            inhibitor_score=float(data["inhibitor_score"]),
+            method_score=float(data["method_score"]),
+            organism_score=float(data["organism_score"]),
+            weighted_score=float(data["weighted_score"]),
+            grade=data["grade"],
+            coverage=_optional_float(data.get("coverage")),
+            has_ligand=data.get("has_ligand"),
+            method=data.get("method"),
+            method_class=data.get("method_class"),
+            organism=data.get("organism"),
+            organism_class=data.get("organism_class"),
+            pdb_id=data.get("pdb_id"),
+            protein_id=data.get("protein_id"),
+            resolution=_optional_float(data.get("resolution")),
+            rfree=_optional_float(data.get("rfree")),
+            source_sha256=data.get("source_sha256"),
+        )
+
+
+def _optional_float(value: Any) -> float | None:
+    """Return ``float(value)`` or ``None`` when ``value`` is ``None``."""
+    if value is None:
+        return None
+    return float(value)
+
+
+def _execution_outputs_dict(dto: dict[str, Any]) -> dict[str, Any]:
+    """Return ``jobOutputs`` from an execution DTO as a dict."""
+    outputs = dto.get("jobOutputs")
+    if isinstance(outputs, dict):
+        return outputs
+    if isinstance(outputs, list) and outputs and isinstance(outputs[0], dict):
+        return outputs[0]
+    return {}
+
+
+def _structure_reports_from_dto(dto: dict[str, Any]) -> list[StructureReportResult]:
+    """Parse ``jobOutputs.structure_reports`` into result objects."""
+    outputs = _execution_outputs_dict(dto)
+    raw_rows = outputs.get("structure_reports")
+    if not isinstance(raw_rows, list) or not raw_rows:
+        raise DeepOriginException(
+            title="Structure Report results missing",
+            message=(
+                "Expected a non-empty jobOutputs.structure_reports list "
+                "on the execution response."
+            ),
+        ) from None
+
+    rows: list[StructureReportResult] = []
+    for index, row in enumerate(raw_rows):
+        if not isinstance(row, dict):
+            raise DeepOriginException(
+                title="Invalid Structure Report row",
+                message=(
+                    f"Expected structure_reports[{index}] to be a dict, "
+                    f"got {type(row).__name__}."
+                ),
+            ) from None
+        rows.append(StructureReportResult.from_json(row))
+    return rows
+
+
+def _normalize_pdb_id(pdb_id: str) -> str:
+    """Validate and normalize a four-character PDB ID.
+
+    Args:
+        pdb_id: Candidate PDB ID.
+
+    Returns:
+        Uppercased PDB ID.
+
+    Raises:
+        ValueError: If ``pdb_id`` is not four alphanumeric characters.
+    """
+    cleaned = pdb_id.strip()
+    if not _PDB_ID_RE.fullmatch(cleaned):
+        raise ValueError(
+            f"pdb_id must be exactly four alphanumeric characters, got {pdb_id!r}."
+        )
+    return cleaned.upper()
+
+
+class StructureReport(Execution, SyncExecutableMixin):
+    """Grade a structure via the Structure Report platform tool.
+
+    Provide a :class:`~deeporigin.drug_discovery.structures.protein.Protein`
+    (local/UFA file), a four-character ``pdb_id`` (remote RCSB metadata only),
+    or both (local file with RCSB as experimental-metadata authority). Call
+    :meth:`run` to execute synchronously and receive
+    :class:`StructureReportResult` rows.
+    """
+
+    tool_key: str = TOOL_KEYS_AND_VERSIONS["structure_report"]["tool_key"]
+
+    @beartype
+    def __init__(
+        self,
+        protein: Protein | None = None,
+        *,
+        pdb_id: str | None = None,
+        tool_version: str = TOOL_KEYS_AND_VERSIONS["structure_report"]["tool_version"],
+        client: DeepOriginClient | None = None,
+        name: str | None = None,
+    ) -> None:
+        """Configure a Structure Report run.
+
+        Args:
+            protein: Local protein with a remote path (synced before ``run``).
+            pdb_id: Four-character PDB ID. Alone enables remote mode; with
+                ``protein``, RCSB supplies experimental metadata.
+            tool_version: Platform tool version (defaults to ``"latest"``).
+            client: Optional API client.
+            name: Optional execution label.
+
+        Raises:
+            ValueError: If neither ``protein`` nor ``pdb_id`` is set, or if
+                ``pdb_id`` is malformed.
+        """
+        super().__init__(client=client)
+        if protein is None and pdb_id is None:
+            raise ValueError("StructureReport requires a protein and/or pdb_id.")
+        self._protein = protein
+        self._pdb_id = _normalize_pdb_id(pdb_id) if pdb_id is not None else None
+        self.tool_version = tool_version
+        self.name = name
+
+    @property
+    def protein(self) -> Protein | None:
+        """Input protein, if configured."""
+        return self._protein
+
+    @property
+    def pdb_id(self) -> str | None:
+        """Four-character PDB ID, if configured."""
+        return self._pdb_id
+
+    def _ensure_protein_remote(self) -> None:
+        """Sync the protein so the tool receives a UFA ``file_path``."""
+        if self._protein is None:
+            return
+        self._protein.sync(lazy=True, client=self.client)
+        self._protein.ensure_remote_path(client=self.client, label="Protein")
+
+    def _make_inputs(self) -> dict[str, Any]:
+        """Build Structure Report tool inputs."""
+        inputs: dict[str, Any] = {}
+        if self._protein is not None:
+            inputs["protein"] = _protein_tool_input(self._protein)
+        if self._pdb_id is not None:
+            inputs["pdb_id"] = self._pdb_id
+        return inputs
+
+    def _make_payload(
+        self,
+        *,
+        approve_amount: int | None,
+        sync: bool,
+    ) -> dict[str, Any]:
+        """Build the body dict for ``client.executions.create``."""
+        payload: dict[str, Any] = {
+            "inputs": self._make_inputs(),
+            "outputs": {},
+            "metadata": {},
+            "sync": sync,
+        }
+        if self.name is not None:
+            payload["name"] = self.name
+        if approve_amount is not None:
+            payload["approveAmount"] = approve_amount
+        return payload
+
+    def run(
+        self,
+        *,
+        quote: bool = False,
+        approve_amount: int | None = None,
+    ) -> list[StructureReportResult] | None:
+        """Run Structure Report synchronously and return graded rows.
+
+        Args:
+            quote: Shorthand for ``approve_amount=0``. Returns ``None`` when the
+                platform returns a quotation.
+            approve_amount: Spend cap forwarded as ``approveAmount``.
+
+        Returns:
+            One or more :class:`StructureReportResult` rows, or ``None`` for
+            quote-only responses.
+
+        Raises:
+            DeepOriginException: If the execution does not succeed or
+                ``jobOutputs.structure_reports`` is missing/invalid.
+        """
+        self._ensure_protein_remote()
+        resolved_amount = 0 if quote else approve_amount
+        response = self._create_execution(
+            data=self._make_payload(
+                approve_amount=resolved_amount,
+                sync=not quote,
+            ),
+        )
+        self.update_from_dto(response)
+
+        if self.status == "Quoted":
+            return None
+
+        final_status = response.get("status")
+        if not is_success_status(final_status):
+            eid = response.get("executionId")
+            reason = response.get("statusReason") or final_status
+            raise DeepOriginException(
+                title="Structure Report run did not succeed",
+                message=(
+                    f"Execution {eid!r} ended with status {final_status!r}: {reason!r}."
+                ),
+            ) from None
+
+        return _structure_reports_from_dto(response)
+
+    @classmethod
+    def from_dto(
+        cls,
+        dto: dict[str, Any],
+        *,
+        client: DeepOriginClient | None = None,
+    ) -> Self:
+        """Construct a ``StructureReport`` from a tools execution DTO.
+
+        Restores ``protein`` and/or ``pdb_id`` from ``userInputs`` (falling back
+        to ``inputs``).
+
+        Args:
+            dto: Execution payload (same shape as ``client.executions.get``).
+            client: Optional API client.
+
+        Returns:
+            A ``StructureReport`` with ``id``, pricing fields, and domain inputs.
+
+        Raises:
+            ValueError: If stored inputs lack both ``protein`` and ``pdb_id``.
+        """
+        instance = super().from_dto(dto, client=client)
+        inputs: dict[str, Any] = dto.get("userInputs") or dto.get("inputs") or {}
+
+        protein_input = inputs.get("protein")
+        pdb_raw = inputs.get("pdb_id")
+        protein: Protein | None = None
+        pdb_id: str | None = None
+
+        if isinstance(protein_input, dict):
+            protein_id = protein_input.get("id")
+            file_path = protein_input.get("file_path")
+            if protein_id is not None:
+                protein = Protein.from_id(
+                    str(protein_id),
+                    client=client,
+                    download=False,
+                    remote_path_override=file_path,
+                )
+            else:
+                name = str(file_path).rsplit("/", 1)[-1] if file_path else "protein"
+                protein = Protein(
+                    name=name,
+                    structure=None,
+                    remote_path=str(file_path) if file_path else None,
+                )
+
+        if isinstance(pdb_raw, str) and pdb_raw.strip():
+            pdb_id = _normalize_pdb_id(pdb_raw)
+
+        if protein is None and pdb_id is None:
+            raise ValueError(
+                "Cannot restore StructureReport: stored inputs lack protein and pdb_id."
+            )
+
+        instance._protein = protein
+        instance._pdb_id = pdb_id
+        return instance

--- a/src/platform/constants.py
+++ b/src/platform/constants.py
@@ -154,6 +154,10 @@ TOOL_KEYS_AND_VERSIONS: dict[str, dict[str, str]] = {
         "tool_key": "deeporigin.metabolism",
         "tool_version": "latest",
     },
+    "structure_report": {
+        "tool_key": "deeporigin.structure-report",
+        "tool_version": "latest",
+    },
     "import_dataset": {
         "tool_key": "deeporigin.import-dataset",
         "tool_version": "latest",

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -117,6 +117,53 @@ MOCK_ADMET_ENDPOINTS: tuple[str, ...] = (
 )
 
 
+def _synthesize_structure_report_row(
+    *,
+    pdb_id: str | None,
+    protein_id: str | None,
+    has_file: bool,
+) -> dict[str, Any]:
+    """Build one synthetic ``structure_reports`` row for the mock server."""
+    if has_file and pdb_id:
+        metadata_source = "file_header+rcsb"
+    elif pdb_id and not has_file:
+        metadata_source = "rcsb"
+    else:
+        metadata_source = "file_header"
+    row: dict[str, Any] = {
+        "metadata_source": metadata_source,
+        "field_status": {
+            "organism": "value",
+            "method": "value",
+            "resolution": "value",
+            "coverage": "value" if has_file else "unknown",
+            "rfree": "value",
+            "inhibitor": "value",
+        },
+        "resolution_score": 0.75,
+        "coverage_score": 0.9 if has_file else 0.0,
+        "rfree_score": 0.8,
+        "inhibitor_score": 1.0,
+        "method_score": 0.95,
+        "organism_score": 1.0,
+        "weighted_score": 0.82,
+        "grade": "A",
+        "coverage": 0.9 if has_file else None,
+        "has_ligand": True,
+        "method": "X-RAY DIFFRACTION",
+        "method_class": "x-ray",
+        "organism": "Homo sapiens",
+        "organism_class": "human",
+        "pdb_id": pdb_id,
+        "protein_id": protein_id,
+        "resolution": 1.5,
+        "rfree": 0.2,
+    }
+    if has_file:
+        row["source_sha256"] = "a" * 64
+    return row
+
+
 def _rbfe_ts(start_dt: datetime, duration_s: float, fraction: float) -> str:
     """Return an ISO-8601 UTC timestamp at *fraction* of the mock run."""
     when = start_dt + timedelta(seconds=duration_s * fraction)
@@ -1554,6 +1601,10 @@ def create_tools_router(
             "deeporigin.system-prep": ("system", "preparedsystem"),
             "deeporigin.protein-prep": ("protein", "preparedprotein"),
             "deeporigin.draco": ("do_patent_molecules", "dopatentmolecule"),
+            "deeporigin.structure-report": (
+                "structure_reports",
+                "structurereport",
+            ),
         }
 
         entry = output_key_map.get(tool_key)
@@ -2416,6 +2467,55 @@ def create_tools_router(
                     "network_html": "<html><body>Konnektor network</body></html>",
                 }
                 executions[execution["executionId"]] = execution
+                return _normalize_execution(execution)
+        if tool_key == "deeporigin.structure-report":
+            if quote_only:
+                execution = _create_execution_dto(
+                    tool_key=tool_key,
+                    tool_version=tool_version,
+                    org_key=org_key,
+                    body=body,
+                )
+                executions[execution["executionId"]] = execution
+                return _normalize_execution(execution)
+            if body.get("sync") is True:
+                execution = _create_blocking_run_dto(
+                    org_key=org_key,
+                    tool_key=tool_key,
+                    tool_version=tool_version,
+                    body=body,
+                )
+                inputs = body.get("inputs", {}) or {}
+                protein_in = inputs.get("protein")
+                pdb_raw = inputs.get("pdb_id")
+                pdb_id = (
+                    str(pdb_raw).upper()
+                    if isinstance(pdb_raw, str) and pdb_raw.strip()
+                    else None
+                )
+                protein_id = None
+                has_file = False
+                if isinstance(protein_in, dict):
+                    has_file = bool(protein_in.get("file_path"))
+                    if protein_in.get("id") is not None:
+                        protein_id = str(protein_in["id"])
+                execution["jobOutputs"] = {
+                    "structure_reports": [
+                        _synthesize_structure_report_row(
+                            pdb_id=pdb_id,
+                            protein_id=protein_id,
+                            has_file=has_file,
+                        )
+                    ]
+                }
+                eid = execution["executionId"]
+                executions[eid] = execution
+                _inject_result_explorer_records_from_outputs(
+                    tool_key=tool_key,
+                    tool_version=tool_version,
+                    execution_id=eid,
+                    job_outputs=execution.get("jobOutputs"),
+                )
                 return _normalize_execution(execution)
         if tool_key == "deeporigin.enumerator" and body.get("sync") is True:
             execution = _build_enumerator_execution(

--- a/tests/test_structure_report.py
+++ b/tests/test_structure_report.py
@@ -1,0 +1,174 @@
+"""Tests for :class:`~deeporigin.drug_discovery.structure_report.StructureReport`."""
+
+from __future__ import annotations
+
+import pytest
+
+from deeporigin.drug_discovery import (
+    Protein,
+    StructureReport,
+    StructureReportResult,
+)
+from deeporigin.drug_discovery.structure_report import (
+    StructureReportResult as StructureReportResultCls,
+)
+from deeporigin.drug_discovery.structure_report import (
+    _structure_reports_from_dto,
+)
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.platform.client import DeepOriginClient
+from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS
+
+
+def test_structure_report_requires_protein_or_pdb_id(
+    client: DeepOriginClient,
+) -> None:
+    """Constructor rejects missing protein and pdb_id."""
+    with pytest.raises(ValueError, match="protein and/or pdb_id"):
+        StructureReport(client=client)
+
+
+def test_structure_report_rejects_malformed_pdb_id(
+    client: DeepOriginClient,
+) -> None:
+    """Constructor validates four-character PDB IDs."""
+    with pytest.raises(ValueError, match="four alphanumeric"):
+        StructureReport(pdb_id="1AB", client=client)
+
+
+def test_structure_report_normalizes_pdb_id(client: DeepOriginClient) -> None:
+    """PDB IDs are uppercased after validation."""
+    job = StructureReport(pdb_id="1abc", client=client)
+    assert job.pdb_id == "1ABC"
+    assert job.protein is None
+    assert job.tool_version == "latest"
+    assert job.tool_key == TOOL_KEYS_AND_VERSIONS["structure_report"]["tool_key"]
+
+
+def test_structure_report_make_payload_pdb_id_only(
+    client: DeepOriginClient,
+) -> None:
+    """Remote mode sends only ``pdb_id``."""
+    job = StructureReport(pdb_id="1ABC", client=client, name="sr-remote")
+    payload = job._make_payload(approve_amount=None, sync=True)
+
+    assert payload["sync"] is True
+    assert payload["name"] == "sr-remote"
+    assert payload["inputs"] == {"pdb_id": "1ABC"}
+    assert "protein" not in payload["inputs"]
+
+
+def test_structure_report_make_payload_with_protein(
+    client: DeepOriginClient,
+    registered_protein: Protein,
+) -> None:
+    """Local mode includes protein tool input and optional pdb_id."""
+    job = StructureReport(
+        protein=registered_protein,
+        pdb_id="1ABC",
+        client=client,
+    )
+    payload = job._make_payload(approve_amount=5, sync=True)
+
+    assert payload["approveAmount"] == 5
+    assert payload["inputs"]["pdb_id"] == "1ABC"
+    protein_in = payload["inputs"]["protein"]
+    assert protein_in["file_path"] == registered_protein.remote_path
+    assert protein_in["id"] == registered_protein.id
+
+
+def test_structure_report_result_from_json_round_trip() -> None:
+    """``from_json`` maps required and optional tool fields."""
+    raw = {
+        "metadata_source": "rcsb",
+        "field_status": {
+            "organism": "value",
+            "method": "value",
+            "resolution": "value",
+            "coverage": "unknown",
+            "rfree": "value",
+            "inhibitor": "value",
+        },
+        "resolution_score": 0.5,
+        "coverage_score": 0.0,
+        "rfree_score": 0.8,
+        "inhibitor_score": 1.0,
+        "method_score": 0.95,
+        "organism_score": 1.0,
+        "weighted_score": 0.7,
+        "grade": "B",
+        "pdb_id": "1ABC",
+        "resolution": 2.0,
+    }
+    row = StructureReportResultCls.from_json(raw)
+    assert isinstance(row, StructureReportResult)
+    assert row.grade == "B"
+    assert row.pdb_id == "1ABC"
+    assert row.coverage is None
+    assert row.source_sha256 is None
+
+
+def test_structure_reports_from_dto_rejects_empty() -> None:
+    """Missing ``structure_reports`` raises."""
+    with pytest.raises(DeepOriginException, match="structure_reports"):
+        _structure_reports_from_dto({"jobOutputs": {}})
+
+
+def test_structure_report_run_pdb_id_only(client: DeepOriginClient) -> None:
+    """``run()`` returns typed rows for remote PDB-ID mode."""
+    job = StructureReport(pdb_id="1abc", client=client)
+    rows = job.run()
+
+    assert rows is not None
+    assert len(rows) == 1
+    assert rows[0].grade == "A"
+    assert rows[0].pdb_id == "1ABC"
+    assert rows[0].metadata_source == "rcsb"
+    assert rows[0].source_sha256 is None
+    assert job.id is not None
+    assert job.status in {"Completed", "Succeeded"}
+
+
+def test_structure_report_run_with_protein(
+    client: DeepOriginClient,
+    registered_protein: Protein,
+) -> None:
+    """``run()`` returns typed rows for local protein (+ optional pdb_id)."""
+    job = StructureReport(
+        protein=registered_protein,
+        pdb_id="1ABC",
+        client=client,
+    )
+    rows = job.run()
+
+    assert rows is not None
+    assert len(rows) == 1
+    assert rows[0].grade == "A"
+    assert rows[0].metadata_source == "file_header+rcsb"
+    assert rows[0].source_sha256 is not None
+    assert rows[0].protein_id == registered_protein.id
+
+
+def test_structure_report_run_quote_returns_none(
+    client: DeepOriginClient,
+) -> None:
+    """Quote-only ``run`` returns ``None`` and leaves status Quoted."""
+    job = StructureReport(pdb_id="1ABC", client=client)
+    assert job.run(quote=True) is None
+    assert job.status == "Quoted"
+    assert job.id is not None
+
+
+def test_structure_report_from_dto_restores_pdb_id(
+    client: DeepOriginClient,
+) -> None:
+    """``from_dto`` restores remote-mode inputs."""
+    job = StructureReport(pdb_id="1ABC", client=client)
+    rows = job.run()
+    assert rows is not None
+
+    dto = client.executions.get(job.id)
+    restored = StructureReport.from_dto(dto, client=client)
+    assert restored.pdb_id == "1ABC"
+    assert restored.protein is None
+    assert restored.id == job.id

--- a/zensical.toml
+++ b/zensical.toml
@@ -37,6 +37,7 @@ nav = [
       {"Molprops" = "dd/tools/molprops.md"},
       {"Metabolism" = "dd/tools/metabolism.md"},
       {"Enumerator" = "dd/tools/enumerator.md"},
+      {"Structure Report" = "dd/tools/structure-report.md"},
       {"ABFE" = "dd/tools/abfe.md"},
       {"RBFE" = "dd/tools/rbfe.md"},
       {"Patent" = "dd/tools/patent.md"},
@@ -70,6 +71,7 @@ nav = [
       {"ProteinPrep" = "dd/ref/protein_prep.md"},
       {"Enumerator" = "dd/ref/enumerator.md"},
       {"Konnektor" = "dd/ref/konnektor.md"},
+      {"StructureReport" = "dd/ref/structure_report.md"},
       {"ABFE" = "dd/ref/abfe.md"},
       {"RBFE" = "dd/ref/rbfe.md"},
       {"Patent" = "dd/ref/patent.md"},
@@ -78,6 +80,7 @@ nav = [
     {"Results" = [
       {"PreparedSystem" = "dd/ref/prepared_system.md"},
       {"KonnektorResult" = "dd/ref/konnektor_result.md"},
+      {"StructureReportResult" = "dd/ref/structure_report_result.md"},
     ]},
   ]},
   {"Platform API" = [


### PR DESCRIPTION
## Summary

- Adds a sync-only `StructureReport` / `StructureReportResult` client for the served `deeporigin.structure-report` tool (protein and/or PDB ID; no public `self_test`)
- `run()` maps `jobOutputs.structure_reports` to typed results; inherits `Execution.get_results` for indexed result-explorer rows
- Mock-server coverage, how-to + API docs, and a clean demo notebook covering both input modes

**Jira:** [DDOS-7377](https://deeporigin.atlassian.net/browse/DDOS-7377)

## Test plan

- [x] `uv run pytest tests/test_structure_report.py --env local -x` (11 passed)
- [ ] Spot-check docs pages for Structure Report in the nav
- [ ] Optional: run dirty notebook against a live org and re-promote if needed

[DDOS-7377]: https://deeporigin.atlassian.net/browse/DDOS-7377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ