### PR TITLE
feat(drug-discovery): Metabolism ligands_file for batches >100 (DDOS-7550)

### DIFF
--- a/docs/dd/tools/metabolism.md
+++ b/docs/dd/tools/metabolism.md
@@ -67,3 +67,7 @@ job.wait()               # or await job.watch() in a notebook
 sites = job.get_results()
 mols = job.get_molecules()
 ```
+
+Batches larger than 100 ligands still use the same API. The client writes a
+Ligand list file, uploads it, and passes that file to the tool automatically —
+you do not choose a separate file input.

--- a/src/drug_discovery/metabolism.py
+++ b/src/drug_discovery/metabolism.py
@@ -19,6 +19,11 @@ not select or filter enzymes. ``tool_version`` stays ``"latest"``. Ligands
 are not mutated. Payload ``id`` is sent only when
 :attr:`~deeporigin.drug_discovery.structures.ligand.Ligand.id` is already set.
 
+Batches larger than the platform Inline ligand cap
+(:data:`~deeporigin.utils.constants.METABOLISM_INLINE_LIGAND_CAP`) dump a
+Ligand list file to UFA and submit ``inputs.ligands_file`` on
+:meth:`start` (transparent to the caller).
+
 Sync usage (blocking; fewer than 30 ligands)::
 
     from deeporigin.drug_discovery import Metabolism, Ligand
@@ -43,7 +48,12 @@ Fetch indexed rows without starting a job::
 
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+import tempfile
 from typing import Any, Self
+import uuid
 import warnings
 
 from beartype import beartype
@@ -61,6 +71,7 @@ from deeporigin.platform.client import DeepOriginClient
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
 from deeporigin.utils.constants import (
     METABOLISM_EXECUTION_TIMEOUT_SECONDS,
+    METABOLISM_INLINE_LIGAND_CAP,
     METABOLISM_LIGAND_ID_QUERY_BATCH_SIZE,
     METABOLISM_RESULT_EXPLORER_PAGE_SIZE,
     METABOLISM_WORKFLOW_LIGAND_THRESHOLD,
@@ -82,6 +93,7 @@ _MOLECULE_COLUMNS: tuple[str, ...] = (
 # not ``x-result-group``). Matches toolbox MetabolismMolecule skip filter.
 _RESULT_TYPE_SITES = "metabolismsite"
 _RESULT_TYPE_MOLECULES = "metabolismmolecule"
+_LIGAND_LIST_UPLOAD_PREFIX = "metabolism/ligand-lists/"
 
 
 def _normalize_ligands(
@@ -216,22 +228,44 @@ def _ordered_dataframe(
     return df[ordered + extra]
 
 
-def _ligands_from_inputs(inputs: dict[str, Any]) -> list[Ligand]:
-    """Rebuild ligands from stored metabolism ``userInputs``.
+def _ligand_payloads(ligands: list[Ligand]) -> list[dict[str, str]]:
+    """Build ``{smiles, id?}`` dicts for tool inputs or a Ligand list file.
 
     Args:
-        inputs: ``userInputs`` or ``inputs`` from an execution DTO.
+        ligands: Ligands to serialize.
+
+    Returns:
+        Payload rows with required ``smiles`` and optional ``id``.
+
+    Raises:
+        ValueError: If a ligand has no SMILES.
+    """
+
+    ligand_payloads: list[dict[str, str]] = []
+    for idx, lig in enumerate(ligands):
+        smiles = lig.smiles or ""
+        if not smiles:
+            raise ValueError(f"ligands[{idx}] has no SMILES.")
+        payload: dict[str, str] = {"smiles": smiles}
+        if lig.id is not None:
+            payload["id"] = str(lig.id)
+        ligand_payloads.append(payload)
+    return ligand_payloads
+
+
+def _ligands_from_payload_rows(raw: list[Any]) -> list[Ligand]:
+    """Rebuild ligands from a bare Ligand list (inline or file JSON array).
+
+    Args:
+        raw: List of ligand dicts with ``smiles`` and optional ``id``.
 
     Returns:
         Ligands with SMILES and optional platform ids restored.
 
     Raises:
-        ValueError: If ligands are missing or a row has no SMILES.
+        ValueError: If a row is not an object or has no SMILES.
     """
 
-    raw = inputs.get("ligands")
-    if not isinstance(raw, list) or not raw:
-        raise ValueError("Cannot rehydrate Metabolism: stored inputs have no ligands.")
     ligands: list[Ligand] = []
     for idx, row in enumerate(raw):
         if not isinstance(row, dict):
@@ -248,6 +282,83 @@ def _ligands_from_inputs(inputs: dict[str, Any]) -> list[Ligand]:
             ligand.id = str(row["id"])
         ligands.append(ligand)
     return ligands
+
+
+def _ligands_from_list_file_bytes(payload: bytes) -> list[Ligand]:
+    """Parse a Ligand list file body into ligands.
+
+    Args:
+        payload: UTF-8 JSON bytes whose root is a bare ligand array.
+
+    Returns:
+        Parsed ligands.
+
+    Raises:
+        ValueError: If the body is not valid UTF-8 JSON or not a ligand array.
+    """
+
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"Cannot rehydrate Metabolism: ligands_file is not valid UTF-8: {exc}"
+        ) from exc
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Cannot rehydrate Metabolism: ligands_file is not valid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError(
+            "Cannot rehydrate Metabolism: ligands_file must be a non-empty JSON array."
+        )
+    return _ligands_from_payload_rows(parsed)
+
+
+def _ligands_from_inputs(
+    inputs: dict[str, Any],
+    *,
+    client: DeepOriginClient | None = None,
+) -> list[Ligand]:
+    """Rebuild ligands from stored metabolism ``userInputs``.
+
+    Prefers inline ``ligands`` when present. Otherwise downloads and parses
+    ``ligands_file`` from UFA.
+
+    Args:
+        inputs: ``userInputs`` or ``inputs`` from an execution DTO.
+        client: Required when rehydrating from ``ligands_file``.
+
+    Returns:
+        Ligands with SMILES and optional platform ids restored.
+
+    Raises:
+        ValueError: If ligands are missing, the file cannot be loaded, or a
+            row has no SMILES.
+    """
+
+    raw = inputs.get("ligands")
+    if isinstance(raw, list) and raw:
+        return _ligands_from_payload_rows(raw)
+
+    remote = inputs.get("ligands_file")
+    if not isinstance(remote, str) or not remote.strip():
+        raise ValueError("Cannot rehydrate Metabolism: stored inputs have no ligands.")
+    if client is None or client.files is None:
+        raise ValueError(
+            "Cannot rehydrate Metabolism: client with files is required "
+            "to download ligands_file."
+        )
+    try:
+        local_path = client.files.download(remote.strip(), direct=True)
+        payload = Path(local_path).read_bytes()
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot rehydrate Metabolism: failed to download ligands_file "
+            f"{remote!r}: {exc}"
+        ) from exc
+    return _ligands_from_list_file_bytes(payload)
 
 
 def _resolve_client(client: DeepOriginClient | None) -> DeepOriginClient:
@@ -486,6 +597,9 @@ class Metabolism(
     ligands (blocking). For larger batches, call :meth:`start`, then
     :meth:`wait` or :meth:`watch`, then :meth:`get_results` /
     :meth:`get_molecules` (data platform first, ``jobOutputs`` fallback).
+    Batches above
+    :data:`~deeporigin.utils.constants.METABOLISM_INLINE_LIGAND_CAP` upload a
+    Ligand list file and pass ``ligands_file`` instead of inline ``ligands``.
 
     Use :meth:`fetch_results` / :meth:`fetch_molecules` to read indexed rows
     for a ligand set without starting a job.
@@ -521,6 +635,7 @@ class Metabolism(
         """
         super().__init__(client=client)
         self._ligands: list[Ligand] = _normalize_ligands(ligands)
+        self._remote_ligands_file: str | None = None
         self.name = (
             name if name is not None else _metabolism_default_name(len(self._ligands))
         )
@@ -590,18 +705,54 @@ class Metabolism(
             columns=_MOLECULE_COLUMNS,
         )
 
+    def _ensure_ligands_file_uploaded(self) -> str:
+        """Dump ligands to JSON, upload to UFA, and return the remote path.
+
+        Caches the remote key on ``_remote_ligands_file`` so a repeated call
+        does not re-upload.
+
+        Returns:
+            UFA path under ``metabolism/ligand-lists/``.
+
+        Raises:
+            ValueError: If the client has no files API.
+        """
+
+        if self._remote_ligands_file is not None:
+            return self._remote_ligands_file
+        if self.client.files is None:
+            raise ValueError(
+                "Cannot upload Ligand list file: client.files is not available."
+            )
+
+        payloads = _ligand_payloads(self._ligands)
+        remote_path = f"{_LIGAND_LIST_UPLOAD_PREFIX}{uuid.uuid4().hex}.json"
+        fd, tmp_name = tempfile.mkstemp(suffix=".json", prefix="metabolism-ligands-")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payloads, handle, allow_nan=False)
+            self.client.files.upload(tmp_name, remote_path)
+        finally:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+        self._remote_ligands_file = remote_path
+        return remote_path
+
     def _make_inputs(self) -> dict[str, Any]:
-        """Build tool ``inputs`` matching the metabolism schema."""
-        ligand_payloads: list[dict[str, str]] = []
-        for idx, lig in enumerate(self._ligands):
-            smiles = lig.smiles or ""
-            if not smiles:
-                raise ValueError(f"ligands[{idx}] has no SMILES.")
-            payload: dict[str, str] = {"smiles": smiles}
-            if lig.id is not None:
-                payload["id"] = str(lig.id)
-            ligand_payloads.append(payload)
-        return {"ligands": ligand_payloads}
+        """Build tool ``inputs`` matching the metabolism schema.
+
+        Batches larger than
+        :data:`~deeporigin.utils.constants.METABOLISM_INLINE_LIGAND_CAP`
+        upload a Ligand list file and return ``ligands_file``; smaller batches
+        send inline ``ligands``.
+        """
+
+        if len(self._ligands) > METABOLISM_INLINE_LIGAND_CAP:
+            return {"ligands_file": self._ensure_ligands_file_uploaded()}
+        return {"ligands": _ligand_payloads(self._ligands)}
 
     def _make_payload(
         self,
@@ -948,6 +1099,8 @@ class Metabolism(
         """Construct a ``Metabolism`` from a tools execution DTO.
 
         Restores ligands from ``userInputs`` (falling back to ``inputs``).
+        When only ``ligands_file`` is present, downloads and parses that UFA
+        Ligand list file.
 
         Args:
             dto: Execution payload (same shape as ``client.executions.get``).
@@ -957,9 +1110,16 @@ class Metabolism(
             A :class:`Metabolism` with ``id``, lifecycle fields, and ligands set.
 
         Raises:
-            ValueError: If stored inputs have no ligands.
+            ValueError: If stored inputs have no ligands, or ``ligands_file``
+                cannot be downloaded or parsed.
         """
         instance = super().from_dto(dto, client=client)
         inputs: dict[str, Any] = dto.get("userInputs") or dto.get("inputs") or {}
-        instance._ligands = _ligands_from_inputs(inputs)
+        instance._ligands = _ligands_from_inputs(
+            inputs,
+            client=instance.client,  # ty:ignore[invalid-argument-type]
+        )
+        remote = inputs.get("ligands_file")
+        if isinstance(remote, str) and remote.strip():
+            instance._remote_ligands_file = remote.strip()
         return instance

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -251,6 +251,12 @@ Matches platform preflight routing: batches at or above this size run as
 workflows. ``run()`` raises for ``len(ligands) >=`` this value; use
 ``start()`` then ``wait()`` / ``watch()``."""
 
+METABOLISM_INLINE_LIGAND_CAP = 100
+"""Max ligands sent inline in Metabolism ``inputs.ligands``.
+
+Matches the platform Inline ligand cap. Larger batches dump a Ligand list
+file to UFA and pass ``inputs.ligands_file`` instead."""
+
 METABOLISM_EXECUTION_TIMEOUT_SECONDS = 900.0
 """HTTP timeout (seconds) for ``deeporigin.metabolism`` sync runs.
 

--- a/tests/mock_server/routers/files.py
+++ b/tests/mock_server/routers/files.py
@@ -86,6 +86,40 @@ def _resolve_file_content(
     raise HTTPException(status_code=404, detail=f"File not found: {remote_path}")
 
 
+def _extract_multipart_file_bytes(content_type: str, body: bytes) -> bytes:
+    """Extract the ``file`` part from a multipart PUT body.
+
+    Avoids requiring ``python-multipart`` in the mock server environment.
+    """
+    boundary: str | None = None
+    for part in content_type.split(";"):
+        part = part.strip()
+        if part.lower().startswith("boundary="):
+            boundary = part.split("=", 1)[1].strip().strip('"')
+            break
+    if not boundary:
+        return body
+
+    marker = b"--" + boundary.encode("ascii", errors="ignore")
+    for section in body.split(marker):
+        header_blob, sep, payload = section.partition(b"\r\n\r\n")
+        if not sep:
+            continue
+        headers = header_blob.decode("latin-1", errors="ignore").lower()
+        if 'name="file"' not in headers and "name=file" not in headers:
+            continue
+        # Trailing CRLF before the next boundary marker.
+        if payload.endswith(b"\r\n"):
+            payload = payload[:-2]
+        # Closing boundary may append "--".
+        if payload.endswith(b"--"):
+            payload = payload[:-2]
+            if payload.endswith(b"\r\n"):
+                payload = payload[:-2]
+        return payload
+    return body
+
+
 def create_files_router(
     file_storage: dict[str, bytes], fixtures_dir: Path
 ) -> APIRouter:
@@ -189,7 +223,12 @@ def create_files_router(
         request: Request,
     ) -> dict[str, str]:
         """Upload a file."""
-        content = await request.body()
+        content_type = request.headers.get("content-type", "")
+        body = await request.body()
+        if "multipart/form-data" in content_type:
+            content = _extract_multipart_file_bytes(content_type, body)
+        else:
+            content = body
         file_storage[remote_path] = content
         return {"eTag": "mock-etag", "key": remote_path}
 

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -1357,6 +1357,18 @@ def create_tools_router(
     ) -> dict[str, list[dict[str, Any]]]:
         """Synthesize metabolism ``sites`` / ``molecules`` from stored inputs."""
         ligands_in = inputs.get("ligands") or []
+        if not ligands_in:
+            remote = inputs.get("ligands_file")
+            if isinstance(remote, str) and remote.strip():
+                key = remote.strip().lstrip("/")
+                raw = file_storage.get(key) or file_storage.get(remote.strip())
+                if raw is not None:
+                    try:
+                        parsed = json.loads(raw.decode("utf-8"))
+                    except (UnicodeDecodeError, json.JSONDecodeError):
+                        parsed = []
+                    if isinstance(parsed, list):
+                        ligands_in = parsed
         sites: list[dict[str, Any]] = []
         molecules: list[dict[str, Any]] = []
         for lig in ligands_in:

--- a/tests/test_metabolism_local.py
+++ b/tests/test_metabolism_local.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 import time
 from typing import TYPE_CHECKING
 
@@ -15,7 +17,10 @@ from deeporigin.platform.constants import (
     TOOL_KEYS_AND_VERSIONS,
     is_success_status,
 )
-from deeporigin.utils.constants import METABOLISM_WORKFLOW_LIGAND_THRESHOLD
+from deeporigin.utils.constants import (
+    METABOLISM_INLINE_LIGAND_CAP,
+    METABOLISM_WORKFLOW_LIGAND_THRESHOLD,
+)
 from tests.conftest import check_tool_exists
 from tests.mock_server.routers.tools import _synthesize_metabolism_outputs
 
@@ -177,6 +182,54 @@ def test_metabolism_start_async_payload(
     dto = job._dto or {}
     assert dto.get("tool", {}).get("key") == "deeporigin.metabolism"
     assert (dto.get("userInputs") or {}).get("ligands") == [{"smiles": "CCO"}]
+
+
+def test_metabolism_start_above_inline_cap_uses_ligands_file(
+    client: DeepOriginClient,
+) -> None:
+    """Batches above the inline cap submit ``ligands_file`` after UFA upload."""
+    _assert_tool_available(client)
+    n = METABOLISM_INLINE_LIGAND_CAP + 1
+    ligands = [Ligand.from_smiles("CCO")] * n
+    job = Metabolism(ligands=ligands, client=client)
+    inputs = job._make_inputs()
+    assert "ligands" not in inputs
+    remote = inputs["ligands_file"]
+    assert remote.startswith("metabolism/ligand-lists/")
+    assert job._remote_ligands_file == remote
+    # Cached path: second call does not re-upload a new key.
+    assert job._make_inputs()["ligands_file"] == remote
+
+    job.start()
+
+    dto = job._dto or {}
+    assert (dto.get("userInputs") or {}).get("ligands_file") == remote
+    assert "ligands" not in (dto.get("userInputs") or {})
+
+    # Uploaded body is a bare ligand array.
+    local = client.files.download(remote, direct=True)
+    parsed = json.loads(Path(local).read_text(encoding="utf-8"))
+    assert isinstance(parsed, list)
+    assert len(parsed) == n
+    assert parsed[0] == {"smiles": "CCO"}
+
+
+def test_metabolism_from_dto_rehydrates_ligands_file(
+    client: DeepOriginClient,
+) -> None:
+    """``from_dto`` downloads ``ligands_file`` and restores ligands."""
+    _assert_tool_available(client)
+    n = METABOLISM_INLINE_LIGAND_CAP + 1
+    job = Metabolism(ligands=[Ligand.from_smiles("CCO")] * n, client=client)
+    job.start()
+    assert job.dto is not None
+
+    restored = Metabolism.from_dto(job.dto, client=client)
+    assert len(restored.ligands) == n
+    assert restored.ligands[0].smiles == "CCO"
+    assert restored._remote_ligands_file == (job.dto.get("userInputs") or {}).get(
+        "ligands_file"
+    )
 
 
 def test_metabolism_start_rejects_non_initial_status(

--- a/tests/test_metabolism_unit.py
+++ b/tests/test_metabolism_unit.py
@@ -19,6 +19,7 @@ from deeporigin.drug_discovery.metabolism import (
 )
 from deeporigin.drug_discovery.structures.ligand import Ligand, LigandSet
 from deeporigin.utils.constants import (
+    METABOLISM_INLINE_LIGAND_CAP,
     METABOLISM_RESULT_EXPLORER_PAGE_SIZE,
     METABOLISM_WORKFLOW_LIGAND_THRESHOLD,
 )
@@ -187,6 +188,44 @@ def test_ligands_from_inputs_rejects_missing_rows() -> None:
         _ligands_from_inputs({"ligands": ["CCO"]})
     with pytest.raises(ValueError, match="no SMILES"):
         _ligands_from_inputs({"ligands": [{"id": "1"}]})
+
+
+def test_ligands_from_inputs_requires_client_for_ligands_file() -> None:
+    """``ligands_file`` rehydration without a files client raises."""
+    with pytest.raises(ValueError, match="client with files"):
+        _ligands_from_inputs({"ligands_file": "metabolism/ligand-lists/x.json"})
+
+
+def test_ligands_from_list_file_bytes_parses_array() -> None:
+    """Bare JSON ligand arrays rehydrate into Ligand objects."""
+    from deeporigin.drug_discovery.metabolism import _ligands_from_list_file_bytes
+
+    raw = b'[{"smiles":"CCO","id":"lig-1"},{"smiles":"CCN"}]'
+    ligands = _ligands_from_list_file_bytes(raw)
+    assert [lig.smiles for lig in ligands] == ["CCO", "CCN"]
+    assert ligands[0].id == "lig-1"
+    assert ligands[1].id is None
+
+
+def test_ligands_from_list_file_bytes_rejects_bad_json() -> None:
+    """Invalid UTF-8 or JSON fails with ValueError."""
+    from deeporigin.drug_discovery.metabolism import _ligands_from_list_file_bytes
+
+    with pytest.raises(ValueError, match="not valid UTF-8"):
+        _ligands_from_list_file_bytes(b"\xff\xfe")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        _ligands_from_list_file_bytes(b"{not-json")
+    with pytest.raises(ValueError, match="non-empty JSON array"):
+        _ligands_from_list_file_bytes(b"{}")
+
+
+def test_make_inputs_stays_inline_at_cap() -> None:
+    """Exactly the inline cap still sends ``ligands[]``."""
+    n = METABOLISM_INLINE_LIGAND_CAP
+    job = Metabolism(ligands=[Ligand.from_smiles("CCO")] * n)
+    inputs = job._make_inputs()
+    assert "ligands_file" not in inputs
+    assert len(inputs["ligands"]) == n
 
 
 def test_platform_ligand_ids_skips_missing_and_blank() -> None:


### PR DESCRIPTION
## Summary

- For `len(ligands) > 100`, `Metabolism` dumps a bare Ligand-list JSON, uploads to `metabolism/ligand-lists/{uuid}.json`, and `start()`s with `inputs.ligands_file` (platform-toolbox metabolism 6.0.0 / PR #981).
- Constructor stays `ligands=`-only; ≤100 stay inline; `run()` still requires &lt;30.
- `from_dto` downloads and parses `ligands_file` (raises `ValueError` on failure).
- Docs + unit/mock-server tests; mock multipart upload extracts the file body without `python-multipart`.

**Jira:** [DDOS-7550](https://deeporigin.atlassian.net/browse/DDOS-7550)

## Test plan

- [x] `uv run pytest --env local -x tests/test_metabolism_unit.py tests/test_metabolism_local.py`
- [ ] Smoke against a live org once metabolism 6.0.0 is deployed: `Metabolism(ligands=[...] * 101).start()` and confirm `userInputs.ligands_file`

[DDOS-7550]: https://deeporigin.atlassian.net/browse/DDOS-7550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ