### PR TITLE
fix(files): always set Content-Length for signed-url uploads (DDOS-7697)

### DIFF
--- a/src/platform/files.py
+++ b/src/platform/files.py
@@ -394,8 +394,7 @@ class Files:
                 headers = {"Content-Type": "application/octet-stream"}
                 if file_size is None:
                     file_size = self._local_file_size(local_path)
-                if file_size > 0:
-                    headers["Content-Length"] = str(file_size)
+                headers["Content-Length"] = str(file_size)
 
                 with httpx.Client(timeout=_SIGNED_URL_UPLOAD_TIMEOUT) as upload_client:
                     resp = upload_client.put(

--- a/tests/test_file_api.py
+++ b/tests/test_file_api.py
@@ -228,6 +228,46 @@ def test_upload_files_via_signed_url_directory_lv1(client: DeepOriginClient):
     )
 
 
+def test_upload_empty_file_via_signed_url_lv1(client: DeepOriginClient):
+    """test uploading a 0-byte file via signed URL and verifying Size in listing."""
+
+    if client.env == "local":
+        pytest.skip("Requires a real file service (use --env dev/staging/prod)")
+
+    remote_dir = f"/testing-empty-signed-url-upload/{uuid.uuid4()}/"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        empty_file = os.path.join(tmpdir, "empty.bin")
+        with open(empty_file, "wb"):
+            pass
+
+        results = client.files.upload_tree(
+            local_path=[empty_file],
+            remote_dir=remote_dir,
+        )
+
+        assert results == [f"{remote_dir}empty.bin"]
+
+    file_objects = client.files.list(
+        remote_path=remote_dir,
+        recursive=True,
+        metadata=True,
+    )
+    size_by_name = {
+        os.path.basename(obj["Key"]): obj["Size"]
+        for obj in file_objects
+        if "Size" in obj
+    }
+
+    assert size_by_name == {"empty.bin": 0}
+
+    client.files.delete_many(
+        remote_paths=results,
+        skip_errors=True,
+        timeout=60.0,
+    )
+
+
 def test_delete_file_lv1(client: DeepOriginClient):
     """test the delete_file API."""
     # First upload a file to delete

--- a/tests/test_files_signed_url_upload.py
+++ b/tests/test_files_signed_url_upload.py
@@ -74,6 +74,39 @@ def test_put_to_signed_url_refreshes_signed_url_on_retry(
     assert put_attempts["count"] == 2
 
 
+def test_put_to_signed_url_sets_content_length_for_empty_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty files must send Content-Length: 0 for presigned S3 PUTs."""
+    local_file = tmp_path / "empty.bin"
+    local_file.write_bytes(b"")
+
+    files = _files_with_mock_client()
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+    observed_headers: dict[str, str] = {}
+
+    def fake_put(*_args: object, **kwargs: object) -> FakeResponse:
+        headers = kwargs["headers"]
+        observed_headers["Content-Length"] = headers["Content-Length"]
+        _consume_upload_body(kwargs["content"])
+        return FakeResponse()
+
+    fake_client = MagicMock()
+    fake_client.put.side_effect = fake_put
+    fake_client.__enter__ = MagicMock(return_value=fake_client)
+    fake_client.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=fake_client))
+
+    files._put_to_signed_url(local_file, "/remote/empty.bin", max_retries=0)
+
+    assert observed_headers["Content-Length"] == "0"
+
+
 def test_put_to_signed_url_streams_file_without_read_bytes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_files_signed_url_upload.py
+++ b/tests/test_files_signed_url_upload.py
@@ -74,39 +74,6 @@ def test_put_to_signed_url_refreshes_signed_url_on_retry(
     assert put_attempts["count"] == 2
 
 
-def test_put_to_signed_url_sets_content_length_for_empty_file(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Empty files must send Content-Length: 0 for presigned S3 PUTs."""
-    local_file = tmp_path / "empty.bin"
-    local_file.write_bytes(b"")
-
-    files = _files_with_mock_client()
-
-    class FakeResponse:
-        def raise_for_status(self) -> None:
-            return None
-
-    observed_headers: dict[str, str] = {}
-
-    def fake_put(*_args: object, **kwargs: object) -> FakeResponse:
-        headers = kwargs["headers"]
-        observed_headers["Content-Length"] = headers["Content-Length"]
-        _consume_upload_body(kwargs["content"])
-        return FakeResponse()
-
-    fake_client = MagicMock()
-    fake_client.put.side_effect = fake_put
-    fake_client.__enter__ = MagicMock(return_value=fake_client)
-    fake_client.__exit__ = MagicMock(return_value=False)
-    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=fake_client))
-
-    files._put_to_signed_url(local_file, "/remote/empty.bin", max_retries=0)
-
-    assert observed_headers["Content-Length"] == "0"
-
-
 def test_put_to_signed_url_streams_file_without_read_bytes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Always set `Content-Length` on presigned S3 PUTs in `Files._put_to_signed_url`, including `0` for empty files.
- Without it, httpx uses `Transfer-Encoding: chunked`, which S3 presigned URLs reject with `501 NotImplemented`.
- Fixes FEP finalize failures on 0-byte `*_nohup.out` files ([DDOS-7697](https://deeporigin.atlassian.net/browse/DDOS-7697)).
- Unit test asserts empty uploads send `Content-Length: 0`.

**Jira:** [DDOS-7697](https://deeporigin.atlassian.net/browse/DDOS-7697)

## Test plan

- [x] `uv run pytest tests/test_files_signed_url_upload.py --env local`
- [ ] CI green on PR
- [ ] After merge: tag and publish `deeporigin-sdk`; bump pin in md-suite

[DDOS-7697]: https://deeporigin.atlassian.net/browse/DDOS-7697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDOS-7697]: https://deeporigin.atlassian.net/browse/DDOS-7697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ