### PR TITLE
feat(molprops): align SDK to mol-props-combined + sa_score (DDOS-7718)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,12 +7,15 @@ system preparation, and free-energy calculations.
 
 **Molprops**:
 Combined platform tool ``deeporigin.mol-props-combined`` for physicochemical
-properties (logP, logD, logS, PAINS). As of tool 0.9.3+, toxicity and metabolism
-endpoints (hERG, CYP, AMES) moved to ``deeporigin.admet-properties``. The CLI class
-``Molprops`` mutates dedicated :class:`~deeporigin.drug_discovery.structures.ligand.Ligand`
-attributes in place.
+properties (logP, logD, logS, PAINS, RDKit descriptors including ``sa_score``).
+As of tool 0.9.3+, toxicity and metabolism endpoints (hERG, CYP, AMES) moved to
+``deeporigin.admet-properties``. The CLI class ``Molprops`` mutates dedicated
+:class:`~deeporigin.drug_discovery.structures.ligand.Ligand` attributes in place
+(attrs-only; not ``properties``). Default ``props`` is the full tool input enum.
+Tool version pin is major ``"1"``.
 _Avoid_: conflating with ``Admet``; calling it "ADMET" when you mean the
-admet-properties tool
+admet-properties tool; storing molprops results only in ``properties``; local
+RDKit ``@property`` methods named like molprops fields
 
 **Admet endpoint**:
 A selectable admet-now task folder name (e.g. ``AMES_classification``) listed on

--- a/docs/dd/how-to/ligands.md
+++ b/docs/dd/how-to/ligands.md
@@ -434,13 +434,15 @@ pairs = result.pairs
     title="Visualization of network"
 ></iframe>
 
-### Predicting ADMET Properties
+### Predicting molecular properties (Molprops)
 
-ADMET (Absorption, Distribution, Metabolism, Excretion, and Toxicity) properties can be predicted for Ligands or LigandSets.
+Physicochemical descriptors and ML properties (logP, logD, logS, PAINS, RDKit
+descriptors including synthetic accessibility) are predicted with
+:class:`~deeporigin.drug_discovery.molprops.Molprops`. For toxicity /
+metabolism-style endpoints (AMES, hERG, CYP), use
+:class:`~deeporigin.drug_discovery.admet.Admet` instead.
 
 === "Ligands"
-
-    Use :class:`~deeporigin.drug_discovery.molprops.Molprops` to predict ADMET properties for one or more ligands:
 
     ```{.python notest}
     from deeporigin.drug_discovery import Molprops
@@ -449,8 +451,8 @@ ADMET (Absorption, Distribution, Metabolism, Excretion, and Toxicity) properties
     mp.run(quote=True)  # optional: platform quote for all ligands → mp.estimate
     mp.run()  # mutates ligands; total USD in mp.cost when available
 
-    # Or request only some models (keys match platform suffixes: ames, logp, logd, …):
-    mp = Molprops(ligands=[ligand], props=["ames", "logp"])
+    # Or request a subset (keys match the combined tool enum):
+    mp = Molprops(ligands=[ligand], props=["logp", "sa_score", "tpsa"])
     mp.run()
     ```
 
@@ -459,50 +461,48 @@ ADMET (Absorption, Distribution, Metabolism, Excretion, and Toxicity) properties
     ``run(quote=True)`` requests a single platform quotation for **every** ligand and every selected property in one call (``batch_size`` is ignored). It populates ``estimate`` (and execution ``id`` / ``status`` via the tools DTO) and does **not** mutate ligands with predictions.
 
     !!! note "Mutation Behavior"
-        `Molprops.run()` mutates each ligand by filling dedicated ADMET attributes (see below), storing values in `ligand.properties`, and setting RDKit molecule properties.
+        `Molprops.run()` mutates each ligand by filling dedicated attributes (see below). Values are not copied into `ligand.properties`.
 
-    The return value is a single flat dict (one row per ligand), for example:
+    Example tool row (one ligand):
 
     ```python
     {
         'ligand_id': '0',
-        'logS': -4.004,                       # Aqueous solubility
-        'logP': 3.686,                        # Partition coefficient
-        'logD': 2.528,                        # Distribution coefficient
-        'ames_probability': 0.213,            # Ames mutagenicity probability
-        'herg_inhibition_probability': 0.264, # hERG inhibition probability
-        'cyp1a2': 0.134,                      # CYP450 inhibition probabilities
-        'cyp2c9': 0.744,
-        'cyp2c19': 0.853,
-        'cyp2d6': 0.0252,
-        'cyp3a4': 0.4718,
-        'has_pains': False,                   # PAINS (Pan Assay Interference Compounds)
+        'logS': -4.004,
+        'logP': 3.686,
+        'logD': 2.528,
+        'has_pains': False,
         'pains_fragments': [],
+        'molecular_weight': 351.4,
+        'hbond_donor_count': 1,
+        'hbond_acceptor_count': 5,
+        'rotatable_bond_count': 6,
+        'tpsa': 67.2,
+        'rule_of_5_violations': 0,
+        'sa_score': 2.81,
     }
     ```
 
-    The same values are exposed as first-class attributes (Python `snake_case` names):
+    The same values are exposed as first-class attributes:
 
-    | API key (in dict / `get_property`) | Ligand attribute |
+    | API key | Ligand attribute |
     |-----------------------------------|------------------|
     | `logS` | `ligand.log_s` |
     | `logD` | `ligand.log_d` |
     | `logP` | `ligand.log_p` |
-    | `ames_probability` | `ligand.ames_probability` |
-    | `herg_inhibition_probability` | `ligand.herg_inhibition_probability` |
-    | `cyp1a2` | `ligand.cyp_1a2` |
-    | `cyp2c9` | `ligand.cyp_2c9` |
-    | `cyp2c19` | `ligand.cyp_2c19` |
-    | `cyp2d6` | `ligand.cyp_2d6` |
-    | `cyp3a4` | `ligand.cyp_3a4` |
     | `has_pains` | `ligand.has_pains` |
     | `pains_fragments` | `ligand.pains_fragments` |
-
-    You can read predictions from attributes or from the properties bag:
+    | `molecular_weight` | `ligand.molecular_weight` |
+    | `hbond_donor_count` | `ligand.hbond_donor_count` |
+    | `hbond_acceptor_count` | `ligand.hbond_acceptor_count` |
+    | `rotatable_bond_count` | `ligand.rotatable_bond_count` |
+    | `tpsa` | `ligand.tpsa` |
+    | `rule_of_5_violations` | `ligand.rule_of_5_violations` |
+    | `sa_score` | `ligand.sa_score` |
 
     ```{.python notest}
     log_p = ligand.log_p
-    log_p = ligand.get_property('logP')
+    sa = ligand.sa_score
     ```
 
 === "LigandSets"
@@ -523,11 +523,11 @@ ADMET (Absorption, Distribution, Metabolism, Excretion, and Toxicity) properties
     The same ``batch_size`` and ``run(quote=True)`` behavior as in the single-ligand tab applies.
 
     !!! note "Mutation Behavior"
-        `Molprops.run()` mutates each ligand by filling the same dedicated ADMET attributes and `.properties` as the single-ligand case.
+        `Molprops.run()` mutates each ligand by filling the same dedicated attributes as the single-ligand case.
 
-    The properties are stored on each ligand (attributes and `.properties`) for later access.
+    Values are stored on each ligand's named attributes for later access.
 
-    To view ADMET properties of all ligands in the ligand set, simply view the ligandset as a dataframe using:
+    To view molprops of all ligands in the ligand set, simply view the ligandset as a dataframe using:
 
     ```{.python notest}
     ligands

--- a/docs/dd/ref/ligand.md
+++ b/docs/dd/ref/ligand.md
@@ -16,16 +16,16 @@
       show_if_no_docstring: true
       group_by_category: true
 
-## ADMET (molprops) attributes
+## Molprops attributes
 
-After you run [`Molprops`](../how-to/ligands.md#predicting-admet-properties) on the ligand, or load the ligand with `Ligand.from_id` / `LigandSet.from_ids` when values already exist on the platform record, scalar predictions are stored on dedicated attributes as well as in `properties` (tool row keys such as `logS`, `cyp2d6`):
+After you run [`Molprops`](../how-to/ligands.md#predicting-molecular-properties-molprops) on the ligand, or load the ligand with `Ligand.from_id` / `LigandSet.from_ids` when values already exist on the platform record, scalar predictions are stored on dedicated attributes (tool row keys such as `logS`, `sa_score`):
 
 - `log_s`, `log_d`, `log_p` — map to tool keys `logS`, `logD`, `logP` (platform columns `logs_predicted`, `logd_predicted`, `log_p`)
-- `ames_probability`, `herg_inhibition_probability` — from `ames_probability`, `herg_probability` on the platform record
-- `cyp_1a2`, `cyp_2c9`, `cyp_2c19`, `cyp_2d6`, `cyp_3a4` — from `cyp1a2`, …, `cyp3a4`
 - `has_pains`, `pains_fragments` — PAINS screening (`pains_flag` on the platform record maps to `has_pains`)
+- `molecular_weight`, `hbond_donor_count`, `hbond_acceptor_count`, `rotatable_bond_count`, `tpsa`, `rule_of_5_violations` — RDKit descriptors (platform pin `rule_of5_violations` maps to `rule_of_5_violations`)
+- `sa_score` — synthetic accessibility (from a `Molprops` run; platform pin pending)
 
-Until molprops has been run or the platform record has pinned values, these fields remain `None`. `pains_fragments` is only available from a fresh `Molprops` run, not from `from_id`.
+Until molprops has been run or the platform record has pinned values, these fields remain `None`. `pains_fragments` is only available from a fresh `Molprops` run when the platform pin is absent. Toxicity endpoints (AMES, hERG, CYP) belong on `Admet`, not Molprops.
 
 ## Preparation
 

--- a/docs/dd/tools/molprops.md
+++ b/docs/dd/tools/molprops.md
@@ -1,5 +1,25 @@
 # Molprops
 
+Predict physicochemical properties and RDKit descriptors for ligands via
+`deeporigin.mol-props-combined` (CLI: `Molprops`).
+
+Requestable keys (default is the full set): `logd`, `logp`, `logs`, `pains`,
+`molecular_weight`, `hbond_donor_count`, `hbond_acceptor_count`,
+`rotatable_bond_count`, `tpsa`, `rule_of_5_violations`, `sa_score`.
+
+Results land on named `Ligand` attributes (for example `ligand.sa_score`,
+`ligand.log_p`), not in `ligand.properties`. Toxicity endpoints belong on
+`Admet`, not Molprops.
+
+```{.python notest}
+from deeporigin.drug_discovery import Ligand, Molprops
+
+ligand = Ligand.from_smiles("CCO")
+Molprops(ligands=[ligand], props=["logp", "sa_score"]).run()
+assert ligand.log_p is not None
+assert ligand.sa_score is not None
+```
+
 ## Working with existing runs
 
 Reconnect to a `Molprops` run started earlier, in this or a previous session,

--- a/docs/notebooks/clean/docking-many-ligands.ipynb
+++ b/docs/notebooks/clean/docking-many-ligands.ipynb
@@ -300,7 +300,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "task = await docking.watch()"
+    "task = await docking.watch(blocking=True)"
    ]
   },
   {

--- a/docs/notebooks/clean/molprops.ipynb
+++ b/docs/notebooks/clean/molprops.ipynb
@@ -30,11 +30,11 @@
    "id": "4fd04396-e167-48ef-bc6c-bf43720da753",
    "metadata": {},
    "source": [
-    "# ADME properties \n",
+    "# Molecular properties (Molprops)\n",
     "\n",
     "## Load a ligand set\n",
     "\n",
-    "Here we load the BRD data set. Note that they have a custom column (`r_exp_dg`)"
+    "Here we load the BRD data set. Note that they have a custom column (`r_exp_dg`).\n"
    ]
   },
   {
@@ -124,7 +124,9 @@
    "id": "7c2bd6e1-9c4c-49fe-84db-8c3674659d9a",
    "metadata": {},
    "source": [
-    "Note that computing molprops on ligands inserts those molprops into the Ligands table; this can be verifief by fetching the Ligand from the ligand table:"
+    "Note that computing molprops on ligands updates named Ligand attributes\n",
+    "(for example `log_p`, `sa_score`); fetch a ligand again to see pinned\n",
+    "platform values hydrated onto those same attributes.\n"
    ]
   },
   {
@@ -134,7 +136,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Ligand.from_id(ligands[0].id).properties"
+    "lig = Ligand.from_id(ligands[0].id)\n",
+    "lig.log_p, lig.sa_score, lig.molecular_weight\n"
    ]
   }
  ],

--- a/src/drug_discovery/molprops.py
+++ b/src/drug_discovery/molprops.py
@@ -1,4 +1,4 @@
-"""Molprops -- synchronous ADMET / molprops runs on one or more ligands.
+"""Molprops -- synchronous molprops runs on one or more ligands.
 
 Backed by the single combined platform tool ``deeporigin.mol-props-combined``,
 which accepts a list of ``ligands`` and a ``molprops`` array selecting which
@@ -7,7 +7,7 @@ properties to compute, and returns one row per input ligand keyed by
 
 Usage::
 
-    mp = Molprops(ligands=[ligand], props=["logp", "logd"])
+    mp = Molprops(ligands=[ligand], props=["logp", "logd", "sa_score"])
     mp.run(quote=True)  # one quote for all ligands + props (ignores ``batch_size``)
     mp.run()  # mutates ligands in place; sets ``cost`` on success
 
@@ -145,13 +145,13 @@ def molprops_quote_total(
 
 
 class Molprops(Execution, SyncExecutableMixin):
-    """Predict molprops / ADMET for ligands via the combined platform tool.
+    """Predict molprops for ligands via the combined platform tool.
 
     Issues one ``client.executions.create`` per batch against
     ``deeporigin.mol-props-combined`` on a normal :meth:`run`, or a single
     quotation request for all ligands when :meth:`run` is called with
     ``quote=True``. Each request carries all selected property keys
-    (e.g. ``logp``, ``logd``). A normal ``run()`` mutates each
+    (e.g. ``logp``, ``sa_score``). A normal ``run()`` mutates each
     passed-in :class:`~deeporigin.drug_discovery.structures.ligand.Ligand`
     in place via
     :meth:`~deeporigin.drug_discovery.structures.ligand.Ligand._apply_molprops_result`.

--- a/src/drug_discovery/structures/ligand.py
+++ b/src/drug_discovery/structures/ligand.py
@@ -69,26 +69,24 @@ def choose_parent_mol(mol: Chem.Mol) -> Chem.Mol:
 
 
 # Keys returned by ``deeporigin.mol-props-combined`` rows → Ligand attribute
-# names (snake_case). Mirrors the ``molprops[*]`` items in the combined tool's
-# output schema.
+# names (snake_case). Mirrors the combined tool's output schema.
 _MOLPROPS_RESPONSE_TO_ATTR: dict[str, str] = {
     "logS": "log_s",
     "logD": "log_d",
     "logP": "log_p",
-    "ames_probability": "ames_probability",
-    "herg_inhibition_probability": "herg_inhibition_probability",
-    "cyp1a2": "cyp_1a2",
-    "cyp2c9": "cyp_2c9",
-    "cyp2c19": "cyp_2c19",
-    "cyp2d6": "cyp_2d6",
-    "cyp3a4": "cyp_3a4",
     "has_pains": "has_pains",
     "pains_fragments": "pains_fragments",
+    "molecular_weight": "molecular_weight",
+    "hbond_donor_count": "hbond_donor_count",
+    "hbond_acceptor_count": "hbond_acceptor_count",
+    "rotatable_bond_count": "rotatable_bond_count",
+    "tpsa": "tpsa",
+    "rule_of_5_violations": "rule_of_5_violations",
+    "sa_score": "sa_score",
 }
 
-# Molprops API row keys that must not be copied into ``properties`` (entity fields
-# or merge keys; see :func:`ligands_to_dataframe` column layout).
-_MOLPROPS_ROW_SKIP_PROPERTY_KEYS: frozenset[str] = frozenset(
+# Molprops API row keys that are identity/merge fields, not Ligand attrs.
+_MOLPROPS_ROW_SKIP_KEYS: frozenset[str] = frozenset(
     {
         "id",
         "ligand_id",
@@ -98,19 +96,20 @@ _MOLPROPS_ROW_SKIP_PROPERTY_KEYS: frozenset[str] = frozenset(
 )
 
 # Platform ligand pinned columns → molprops combined-tool row keys.
-# Mirrors ``pinned-columns.registry.ts`` on the data platform.
+# Mirrors ``pinned-columns.registry.ts`` on the data platform (current tool
+# outputs only; ames/herg/cyp pins are legacy and ignored).
 _PLATFORM_PINNED_TO_MOLPROPS_ROW: dict[str, str] = {
     "log_p": "logP",
     "pains_flag": "has_pains",
+    "pains_fragments": "pains_fragments",
     "logd_predicted": "logD",
     "logs_predicted": "logS",
-    "ames_probability": "ames_probability",
-    "herg_probability": "herg_inhibition_probability",
-    "cyp1a2": "cyp1a2",
-    "cyp2c9": "cyp2c9",
-    "cyp2c19": "cyp2c19",
-    "cyp2d6": "cyp2d6",
-    "cyp3a4": "cyp3a4",
+    "molecular_weight": "molecular_weight",
+    "hbond_donor_count": "hbond_donor_count",
+    "hbond_acceptor_count": "hbond_acceptor_count",
+    "rotatable_bond_count": "rotatable_bond_count",
+    "tpsa": "tpsa",
+    "rule_of5_violations": "rule_of_5_violations",
 }
 
 
@@ -211,11 +210,11 @@ class Ligand(Entity):
     (ligands) in computational drug discovery. It supports various input formats and provides
     methods for property prediction, visualization, and file operations.
 
-    After running :class:`~deeporigin.drug_discovery.molprops.Molprops`, predicted ADMET values
-    are available on dedicated attributes (``log_s``, ``log_d``, ``log_p``,
-    ``ames_probability``, ``herg_inhibition_probability``, ``cyp_1a2``,
-    ``cyp_2c9``, ``cyp_2c19``, ``cyp_2d6``, ``cyp_3a4``, ``has_pains``,
-    ``pains_fragments``) as well as in :attr:`properties`.
+    After running :class:`~deeporigin.drug_discovery.molprops.Molprops`, predicted
+    physicochemical values are available on dedicated attributes (``log_s``,
+    ``log_d``, ``log_p``, ``has_pains``, ``pains_fragments``, ``molecular_weight``,
+    ``hbond_donor_count``, ``hbond_acceptor_count``, ``rotatable_bond_count``,
+    ``tpsa``, ``rule_of_5_violations``, ``sa_score``).
 
     The RDKit molecule must be passed as the keyword-only argument ``mol`` (typically via
     :meth:`from_smiles`, :meth:`from_rdkit_mol`, or similar factory methods).
@@ -236,20 +235,19 @@ class Ligand(Entity):
     mol: Chem.Mol = field(kw_only=True)
     protonated_at_ph: float | None = None
     protonation_concentration: float | None = None
-    # Molprops / ADMET (populated by Molprops.run(); see _MOLPROPS_RESPONSE_TO_ATTR
-    # for the API-key → attribute mapping for the combined molprops tool).
+    # Molprops (populated by Molprops.run(); see _MOLPROPS_RESPONSE_TO_ATTR).
     log_s: float | None = None
     log_d: float | None = None
     log_p: float | None = None
-    ames_probability: float | None = None
-    herg_inhibition_probability: float | None = None
-    cyp_1a2: float | None = None
-    cyp_2c9: float | None = None
-    cyp_2c19: float | None = None
-    cyp_2d6: float | None = None
-    cyp_3a4: float | None = None
     has_pains: bool | None = None
     pains_fragments: list[Any] | None = None
+    molecular_weight: float | None = None
+    hbond_donor_count: int | None = None
+    hbond_acceptor_count: int | None = None
+    rotatable_bond_count: int | None = None
+    tpsa: float | None = None
+    rule_of_5_violations: int | None = None
+    sa_score: float | None = None
 
     # Additional attributes that are initialized in __post_init__
     available_for_docking: bool = field(init=False, default=True)
@@ -635,9 +633,9 @@ class Ligand(Entity):
     ) -> Self:
         """Create a Ligand instance from a platform ligand record.
 
-        When the record includes pinned molprops columns (``log_p``, ``cyp2d6``,
-        ``logs_predicted``, etc.), they are applied to ADMET attributes and
-        :attr:`properties` via :meth:`_apply_molprops_result`.
+        When the record includes pinned molprops columns (``log_p``,
+        ``molecular_weight``, ``logs_predicted``, etc.), they are applied to
+        dedicated molprops attributes via :meth:`_apply_molprops_result`.
 
         Args:
             data: Ligand record returned by the platform entities API.
@@ -1069,51 +1067,6 @@ class Ligand(Entity):
             int: The sum of formal charges of all atoms in the molecule.
         """
         return sum(atom.GetFormalCharge() for atom in self.mol.GetAtoms())
-
-    @property
-    def molecular_weight(self) -> float:
-        """Compute the exact molecular weight of the ligand molecule.
-
-        Returns:
-            float: The exact molecular weight in atomic mass units.
-        """
-        return rdMolDescriptors.CalcExactMolWt(self.mol)
-
-    @property
-    def hbond_donor_count(self) -> int:
-        """Compute the number of hydrogen bond donors in the ligand molecule.
-
-        Returns:
-            int: The number of hydrogen bond donors.
-        """
-        return rdMolDescriptors.CalcNumHBD(self.mol)
-
-    @property
-    def hbond_acceptor_count(self) -> int:
-        """Compute the number of hydrogen bond acceptors in the ligand molecule.
-
-        Returns:
-            int: The number of hydrogen bond acceptors.
-        """
-        return rdMolDescriptors.CalcNumHBA(self.mol)
-
-    @property
-    def rotatable_bond_count(self) -> int:
-        """Compute the number of rotatable bonds in the ligand molecule.
-
-        Returns:
-            int: The number of rotatable bonds.
-        """
-        return rdMolDescriptors.CalcNumRotatableBonds(self.mol)
-
-    @property
-    def tpsa(self) -> float:
-        """Compute the Topological Polar Surface Area (TPSA) of the ligand molecule.
-
-        Returns:
-            float: The TPSA value in square Angstroms.
-        """
-        return rdMolDescriptors.CalcTPSA(self.mol)
 
     @property
     def canonical_smiles(self) -> str:
@@ -1715,15 +1668,11 @@ class Ligand(Entity):
 
     @beartype
     def _apply_molprops_result(self, props: dict[str, Any]) -> None:
-        """Apply merged molprops API row to ADMET fields and ``properties``."""
+        """Apply a molprops API row to dedicated Ligand attributes only."""
 
         for api_key, attr_name in _MOLPROPS_RESPONSE_TO_ATTR.items():
             if api_key in props:
                 setattr(self, attr_name, props[api_key])
-        for key, value in props.items():
-            if key in _MOLPROPS_ROW_SKIP_PROPERTY_KEYS:
-                continue
-            self.set_property(key, value)
 
     def update_coordinates(self, coordinates: np.ndarray):
         """update coordinates of the ligand structure"""
@@ -1839,30 +1788,41 @@ def ligands_to_dataframe(ligands: list[Ligand]) -> pd.DataFrame:
 
     Returns:
         DataFrame with columns ``id``, ``SMILES``, known molprops output keys
-        (in schema order when present), then any other property keys sorted.
+        (in schema order when present on any ligand), then any other
+        :attr:`~Ligand.properties` keys sorted.
     """
 
     skip_property_keys = {
         "_Name",
         "_SMILES",
         "initial_smiles",
-    } | _MOLPROPS_ROW_SKIP_PROPERTY_KEYS
+    } | _MOLPROPS_ROW_SKIP_KEYS
+
+    molprops_keys = [
+        api_key
+        for api_key, attr_name in _MOLPROPS_RESPONSE_TO_ATTR.items()
+        if any(getattr(ligand, attr_name, None) is not None for ligand in ligands)
+    ]
 
     all_keys: set[str] = set()
     for ligand in ligands:
         all_keys.update(ligand.properties.keys())
 
-    property_keys = sorted(k for k in all_keys if k not in skip_property_keys)
-    molprops_keys = [k for k in _MOLPROPS_RESPONSE_TO_ATTR if k in property_keys]
-    other_keys = sorted(set(property_keys) - set(molprops_keys))
+    other_keys = sorted(
+        k
+        for k in all_keys
+        if k not in skip_property_keys and k not in _MOLPROPS_RESPONSE_TO_ATTR
+    )
 
-    property_columns: dict[str, list[Any]] = {}
-    for key in molprops_keys + other_keys:
-        property_columns[key] = [ligand.properties.get(key, None) for ligand in ligands]
-
-    data: dict[str, list[Any]] = {"id": [ligand.id for ligand in ligands]}
-    data["SMILES"] = [ligand.smiles for ligand in ligands]
-    data.update(property_columns)
+    data: dict[str, list[Any]] = {
+        "id": [ligand.id for ligand in ligands],
+        "SMILES": [ligand.smiles for ligand in ligands],
+    }
+    for api_key in molprops_keys:
+        attr_name = _MOLPROPS_RESPONSE_TO_ATTR[api_key]
+        data[api_key] = [getattr(ligand, attr_name, None) for ligand in ligands]
+    for key in other_keys:
+        data[key] = [ligand.properties.get(key, None) for ligand in ligands]
 
     column_order = ["id", "SMILES", *molprops_keys, *other_keys]
     return pd.DataFrame(data)[column_order]

--- a/src/platform/constants.py
+++ b/src/platform/constants.py
@@ -112,7 +112,7 @@ TOOL_KEYS_AND_VERSIONS: dict[str, dict[str, str]] = {
     },
     "mol_props": {
         "tool_key": "deeporigin.mol-props-combined",
-        "tool_version": "latest",
+        "tool_version": "1",
     },
     "protonation": {
         "tool_key": "deeporigin.mol-props-protonation",

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -42,6 +42,13 @@ LIGAND_MOLPROPS_SET_FIELDS: frozenset[str] = frozenset(
         "hbond_acceptor_count",
         "rotatable_bond_count",
         "tpsa",
+        "rule_of_5_violations",
+        "sa_score",
+        "log_p",
+        "log_d",
+        "log_s",
+        "has_pains",
+        "pains_fragments",
     )
 )
 """Ligand ``set`` fields computed by molprops; not writable on create/update."""
@@ -231,12 +238,24 @@ TOOL_KEY_PREFIX = "deeporigin."
 """Platform tool-key prefix omitted in compact display (e.g. user log tables)."""
 
 MOLPROPS_PROPERTY_KEYS: frozenset[str] = frozenset(
-    ("logd", "logp", "logs", "pains"),
+    (
+        "hbond_acceptor_count",
+        "hbond_donor_count",
+        "logd",
+        "logp",
+        "logs",
+        "molecular_weight",
+        "pains",
+        "rotatable_bond_count",
+        "rule_of_5_violations",
+        "sa_score",
+        "tpsa",
+    ),
 )
-"""Allowed molprops tool suffix keys (``deeporigin.mol-props-<key>``)."""
+"""Allowed ``inputs.molprops`` keys for ``deeporigin.mol-props-combined``."""
 
 MOLPROPS_DEFAULT_PROPERTIES: frozenset[str] = MOLPROPS_PROPERTY_KEYS
-"""Default full ADMET bundle for :class:`~deeporigin.drug_discovery.molprops.Molprops`."""
+"""Default property set for :class:`~deeporigin.drug_discovery.molprops.Molprops` (full tool enum)."""
 
 ADMET_EXECUTION_TIMEOUT_SECONDS = 900.0
 """HTTP timeout (seconds) for ``deeporigin.admet-properties`` sync runs.

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -667,19 +667,11 @@ def _synthesize_molprops_row(
 ) -> dict[str, Any]:
     """Build a synthetic combined-molprops output row for one ligand.
 
-    Includes only the output keys for properties named in ``requested`` (see
-    the combined tool's input schema for valid property keys: ``ames``,
-    ``cyp``, ``herg``, ``logd``, ``logp``, ``logs``, ``pains``).
+    Includes only the output keys for properties named in ``requested``
+    (``deeporigin.mol-props-combined`` input enum).
     """
     row: dict[str, Any] = {"ligand_id": ligand_id}
     seed = smiles or ligand_id
-    if "ames" in requested:
-        row["ames_probability"] = round(_stable_unit_float(seed, "ames"), 6)
-    if "herg" in requested:
-        row["herg_inhibition_probability"] = round(_stable_unit_float(seed, "herg"), 6)
-    if "cyp" in requested:
-        for iso in ("cyp1a2", "cyp2c9", "cyp2c19", "cyp2d6", "cyp3a4"):
-            row[iso] = round(_stable_unit_float(seed, iso), 6)
     if "logd" in requested:
         row["logD"] = _stable_log_value(seed, "logd", low=-2.0, high=6.0)
     if "logp" in requested:
@@ -689,6 +681,22 @@ def _synthesize_molprops_row(
     if "pains" in requested:
         row["has_pains"] = False
         row["pains_fragments"] = []
+    if "molecular_weight" in requested:
+        row["molecular_weight"] = round(
+            50.0 + 200.0 * _stable_unit_float(seed, "mw"), 3
+        )
+    if "hbond_donor_count" in requested:
+        row["hbond_donor_count"] = int(_stable_unit_float(seed, "hbd") * 5)
+    if "hbond_acceptor_count" in requested:
+        row["hbond_acceptor_count"] = int(_stable_unit_float(seed, "hba") * 8)
+    if "rotatable_bond_count" in requested:
+        row["rotatable_bond_count"] = int(_stable_unit_float(seed, "rot") * 10)
+    if "tpsa" in requested:
+        row["tpsa"] = round(10.0 + 140.0 * _stable_unit_float(seed, "tpsa"), 3)
+    if "rule_of_5_violations" in requested:
+        row["rule_of_5_violations"] = int(_stable_unit_float(seed, "ro5") * 5) % 5
+    if "sa_score" in requested:
+        row["sa_score"] = round(1.0 + 9.0 * _stable_unit_float(seed, "sa"), 4)
     return row
 
 

--- a/tests/test_ligand.py
+++ b/tests/test_ligand.py
@@ -598,7 +598,7 @@ def test_ligand_property_management():
 
 
 def test_ligand_from_platform_record_hydrates_molprops():
-    """Pinned platform molprops columns map to tool row keys and ADMET attrs."""
+    """Pinned platform molprops columns map to tool row keys and Ligand attrs."""
     from deeporigin.drug_discovery.structures.ligand import (
         _molprops_row_from_platform_record,
     )
@@ -610,17 +610,25 @@ def test_ligand_from_platform_record_hydrates_molprops():
         "logs_predicted": -3.0474026203155518,
         "logd_predicted": 0.9802079200744629,
         "pains_flag": True,
+        "molecular_weight": 351.4,
+        "hbond_donor_count": 1,
+        "hbond_acceptor_count": 5,
+        "rotatable_bond_count": 6,
+        "tpsa": 67.2,
+        "rule_of5_violations": 0,
         "ames_probability": 0.0012685793917626143,
         "herg_probability": 0.17195460200309753,
         "cyp2d6": 0.012631930410861969,
-        "cyp3a4": 0.1912640929222107,
     }
     row = _molprops_row_from_platform_record(data)
     assert row["logP"] == pytest.approx(1.377760887145996)
     assert row["logS"] == pytest.approx(-3.0474026203155518)
     assert row["logD"] == pytest.approx(0.9802079200744629)
     assert row["has_pains"] is True
-    assert row["herg_inhibition_probability"] == pytest.approx(0.17195460200309753)
+    assert row["molecular_weight"] == pytest.approx(351.4)
+    assert row["rule_of_5_violations"] == 0
+    assert "ames_probability" not in row
+    assert "cyp2d6" not in row
 
     ligand = Ligand.from_smiles(data["smiles"])
     ligand._apply_molprops_result(row)
@@ -629,13 +637,11 @@ def test_ligand_from_platform_record_hydrates_molprops():
     assert ligand.log_s == pytest.approx(-3.0474026203155518)
     assert ligand.log_d == pytest.approx(0.9802079200744629)
     assert ligand.has_pains is True
-    assert ligand.ames_probability == pytest.approx(0.0012685793917626143)
-    assert ligand.herg_inhibition_probability == pytest.approx(0.17195460200309753)
-    assert ligand.cyp_2d6 == pytest.approx(0.012631930410861969)
-    assert ligand.cyp_3a4 == pytest.approx(0.1912640929222107)
-    assert ligand.properties["cyp2d6"] == pytest.approx(0.012631930410861969)
-    assert ligand.properties["logS"] == pytest.approx(-3.0474026203155518)
-    assert ligand.properties["logP"] == pytest.approx(1.377760887145996)
+    assert ligand.molecular_weight == pytest.approx(351.4)
+    assert ligand.hbond_donor_count == 1
+    assert ligand.rule_of_5_violations == 0
+    assert "logP" not in ligand.properties
+    assert "molecular_weight" not in ligand.properties
 
 
 def test_to_sdf_requires_rehydration_when_remote_path_only():

--- a/tests/test_ligand_set.py
+++ b/tests/test_ligand_set.py
@@ -532,7 +532,7 @@ def test_ligandset_to_dataframe():
 
 
 def test_ligandset_to_dataframe_after_molprops():
-    """Molprops rows must not duplicate id/SMILES; columns are id, SMILES, then ADMET."""
+    """Molprops rows must not duplicate id/SMILES; columns are id, SMILES, then attrs."""
     from deeporigin.drug_discovery.structures.ligand import LigandSet
 
     ligand = Ligand.from_smiles("CCO")
@@ -542,17 +542,19 @@ def test_ligandset_to_dataframe_after_molprops():
             "ligand_id": "0",
             "smiles": "CCO",
             "logP": 1.2,
-            "cyp2c19": 0.5,
+            "sa_score": 2.5,
         }
     )
 
     df = LigandSet(ligands=[ligand]).to_dataframe()
 
-    assert list(df.columns) == ["id", "SMILES", "logP", "cyp2c19"]
+    assert list(df.columns) == ["id", "SMILES", "logP", "sa_score"]
     assert "ligand_id" not in df.columns
     assert "smiles" not in df.columns
     assert df.loc[0, "id"] == "0"
     assert df.loc[0, "SMILES"] == "CCO"
+    assert df.loc[0, "logP"] == pytest.approx(1.2)
+    assert df.loc[0, "sa_score"] == pytest.approx(2.5)
 
 
 def test_ligandset_indexing_and_slicing():

--- a/tests/test_ligand_set.py
+++ b/tests/test_ligand_set.py
@@ -520,14 +520,16 @@ def test_ligandset_to_dataframe():
 
     ligandset = LigandSet(ligands=[ligand1, ligand2])
 
-    # Add properties
-    ligand1.set_property("logP", 0.32)
-    ligand2.set_property("logP", 0.88)
+    # Add properties. Uses a generic property name rather than "logP" since
+    # molprops keys are now sourced only from dedicated Ligand attributes
+    # (see _MOLPROPS_RESPONSE_TO_ATTR), not from arbitrary set_property calls.
+    ligand1.set_property("custom_score", 0.32)
+    ligand2.set_property("custom_score", 0.88)
 
     df = ligandset.to_dataframe()
     assert len(df) == 2
     assert "SMILES" in df.columns
-    assert "logP" in df.columns
+    assert "custom_score" in df.columns
     assert list(df.columns[:2]) == ["id", "SMILES"]
 
 

--- a/tests/test_molprops.py
+++ b/tests/test_molprops.py
@@ -25,15 +25,16 @@ def test_molprops_lv1(client: DeepOriginClient) -> None:
     mp = Molprops(
         ligands=[ligand],
         client=client,
-        properties={"logs", "logd", "logp"},
+        properties={"logs", "logd", "logp", "sa_score"},
     )
     mp.run()
 
-    if ligand.log_p is None and ligand.get_property("logP") is None:
+    if ligand.log_p is None:
         pytest.skip("Molprops returned no results; platform tool may be unavailable.")
-    assert ligand.get_property("logP") is not None or ligand.log_p is not None
-    assert ligand.get_property("logD") is not None or ligand.log_d is not None
-    assert ligand.get_property("logS") is not None or ligand.log_s is not None
+    assert ligand.log_p is not None
+    assert ligand.log_d is not None
+    assert ligand.log_s is not None
+    assert ligand.sa_score is not None
 
 
 def test_molprops_run_quote_true_full_payload(

--- a/tests/test_molprops_local.py
+++ b/tests/test_molprops_local.py
@@ -30,3 +30,26 @@ def test_molprops_run_syncs_status_from_execution_dto(
     assert job.status == "Completed"
     assert job.id is not None
     assert job.id != "prior-quote-id"
+    assert ligand.log_p is not None
+    assert ligand.sa_score is None
+
+
+def test_molprops_run_applies_sa_score(client: DeepOriginClient) -> None:
+    """``sa_score`` lands on a named Ligand attribute, not ``properties``."""
+    mp_cfg = TOOL_KEYS_AND_VERSIONS["mol_props"]
+    assert check_tool_exists(client, mp_cfg["tool_key"], mp_cfg["tool_version"])
+
+    ligand = Ligand.from_smiles("CCO")
+    Molprops(ligands=[ligand], props=["sa_score"], client=client).run()
+
+    assert ligand.sa_score is not None
+    assert "sa_score" not in ligand.properties
+
+
+def test_molprops_default_props_are_full_enum() -> None:
+    """Omitting props requests every tool input key."""
+    from deeporigin.utils.constants import MOLPROPS_PROPERTY_KEYS
+
+    ligand = Ligand.from_smiles("CCO")
+    job = Molprops(ligands=[ligand])
+    assert job.properties == MOLPROPS_PROPERTY_KEYS


### PR DESCRIPTION
## Summary

- Align `Molprops` to `deeporigin.mol-props-combined`: full allowlist + default all 11 keys (including `sa_score`), major tool pin `"1"`.
- Named `Ligand` attrs for every current tool output; replace clashing local RDKit `@property` methods with stored fields; attrs-only apply (no `properties` dual-write); strip ames/herg/cyp from the molprops Ligand surface.
- Update mock server, tests, docs, notebook, and `CONTEXT.md`.

**Jira:** [DDOS-7718](https://deeporigin.atlassian.net/browse/DDOS-7718)

## Test plan

- [x] `uv run pytest --env local -x tests/test_molprops_local.py tests/test_ligand.py::test_ligand_from_platform_record_hydrates_molprops tests/test_ligand_set.py::test_ligandset_to_dataframe_after_molprops`
- [ ] After merge / tool register: `uv run pytest tests/test_molprops.py --env dev` (needs `sa_score` on env)


Made with [Cursor](https://cursor.com)

[DDOS-7718]: https://deeporigin.atlassian.net/browse/DDOS-7718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ