### PR TITLE
fix(notebooks): set JOB_WATCH_BLOCK=1 for headless notebook execution

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,7 +1,10 @@
 """Tests that execute Jupyter notebooks end-to-end via nbconvert."""
 
+import os
 from pathlib import Path
 import subprocess
+
+from deeporigin.utils.constants import JOB_WATCH_BLOCK_ENV
 
 NOTEBOOKS_DIR = Path(__file__).resolve().parent.parent / "docs" / "notebooks" / "clean"
 
@@ -19,6 +22,12 @@ def _execute_notebook(notebook_path: Path) -> None:
         notebook_path.stem + "_executed" + notebook_path.suffix
     )
 
+    # Notebooks call the non-blocking NotebookWatchMixin.watch() by design
+    # (it's what a real interactive session should do); headless execution
+    # needs JOB_WATCH_BLOCK=1 so the cell waits for the job instead of
+    # racing ahead, same as scripts/build_docs.sh does for the doc build.
+    env = {**os.environ, JOB_WATCH_BLOCK_ENV: "1"}
+
     try:
         result = subprocess.run(
             [
@@ -35,6 +44,7 @@ def _execute_notebook(notebook_path: Path) -> None:
             capture_output=True,
             text=True,
             timeout=600,
+            env=env,
         )
 
         assert result.returncode == 0, (


### PR DESCRIPTION
## Summary

- `tests/test_notebooks.py::test_bulk_docking_notebook` was pre-existing red on `main`, failing at `docking.get_results()`/`protein.show(poses=...)` depending on timing.
- Root cause: `Docking.watch()` (and its siblings — ABFE, RBFE, ConstrainedDocking, Patent) is non-blocking by design, returning a background `asyncio.Task` so a real interactive session gets a live-updating progress card. `tests/test_notebooks.py`'s `nbconvert --execute` subprocess never set `JOB_WATCH_BLOCK=1`, unlike `scripts/build_docs.sh`, so `get_results()`/`get_poses()` raced ahead of the mock execution reaching a terminal state.
- Fix sets `JOB_WATCH_BLOCK=1` on the subprocess env in `_execute_notebook`, matching the mechanism already documented in `NotebookWatchMixin.watch()`'s docstring and used by `scripts/build_docs.sh`. The doc notebook itself (`docking-many-ligands.ipynb`) is untouched — it still shows the real interactive (non-blocking) pattern.

## Test plan

- [x] `uv run pytest tests/test_notebooks.py --env local -v` — 5/5 pass (was 1 failing)
- [x] `uv run pytest tests/test_notebooks.py::test_bulk_docking_notebook --env local -v` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)