### PR TITLE
feat(drug-discovery): add SecondaryPharmacology SDK class (DDOS-7332)

### DIFF
--- a/docs/dd/ref/secondary_pharma.md
+++ b/docs/dd/ref/secondary_pharma.md
@@ -1,0 +1,24 @@
+# `deeporigin.drug_discovery.secondary_pharma`
+
+`SecondaryPharmacology` drives platform tool `deeporigin.secondary-pharma`. It
+scores ligands against a baked kinase panel, using either a served ligand-ML
+path (`method="ligand-ml"`, use `run()`) or an async docking workflow
+(`method="docking"`, use `start()`). See the
+[tool guide](../tools/secondary-pharma.md) for the full explanation of why
+these are separate execution modes on one class.
+
+::: src.drug_discovery.secondary_pharma
+    options:
+      docstring_style: google
+      show_root_heading: false
+      show_category_heading: true
+      show_object_full_path: false
+      show_root_toc_entry: false
+      inherited_members: true
+      members_order: alphabetical
+      filters:
+        - "!^_"  # Exclude private members (names starting with "_")
+      show_signature: true
+      show_signature_annotations: true
+      show_if_no_docstring: true
+      group_by_category: true

--- a/docs/dd/tools/secondary-pharma.md
+++ b/docs/dd/tools/secondary-pharma.md
@@ -20,15 +20,15 @@ you which to call instead:
 
 ```mermaid
 flowchart TD
-    ctor["SecondaryPharmacology(method=...)"]
-    ctor -->|" method='ligand-ml' "| ml_run["run()"]
-    ctor -->|" method='docking' "| dock_start["start()"]
+    ctor["SecondaryPharmacology(method=...)"] --> choose{"Choose method"}
+    choose -->|"&nbsp;method='ligand-ml'&nbsp;"| ml_run["run()<br/>served, synchronous scoring"]
+    choose -->|"&nbsp;method='docking'&nbsp;"| dock_start["start()<br/>async Argo workflow"]
 
-    ml_run -->|" completes "| ml_results["get_results()<br/>DataFrame, returned immediately"]
-    ml_run -.->|" start() raises "| blocked(["✗"])
+    ml_run -->|"&nbsp;completes&nbsp;"| ml_results["get_results()<br/>DataFrame, returned immediately"]
+    ml_run -.->|"&nbsp;start() raises&nbsp;"| blocked(("ValueError"))
 
-    dock_start -->|" submits "| dock_wait["wait() / watch()"]
-    dock_start -.->|" run() raises "| blocked
+    dock_start -->|"&nbsp;submits&nbsp;"| dock_wait["wait() / watch()<br/>poll until complete"]
+    dock_start -.->|"&nbsp;run() raises&nbsp;"| blocked
     dock_wait --> dock_results["get_results()<br/>DataFrame, from the platform"]
     dock_results --> dock_poses["get_poses()<br/>downloaded PoseSet"]
 ```

--- a/docs/dd/tools/secondary-pharma.md
+++ b/docs/dd/tools/secondary-pharma.md
@@ -21,17 +21,16 @@ you which to call instead:
 ```mermaid
 flowchart TD
     ctor["SecondaryPharmacology(method=...)"]
-    ctor -->|"method='ligand-ml'"| ml_run["run()"]
-    ctor -->|"method='docking'"| dock_start["start()"]
+    ctor -->|" method='ligand-ml' "| ml_run["run()"]
+    ctor -->|" method='docking' "| dock_start["start()"]
 
-    ml_run --> ml_results["get_results()\nDataFrame, returned immediately"]
+    ml_run -->|" completes "| ml_results["get_results()<br/>DataFrame, returned immediately"]
+    ml_run -.->|" start() raises "| blocked(["✗"])
 
-    dock_start --> dock_wait["wait() / watch()"]
-    dock_wait --> dock_results["get_results()\nDataFrame, from the platform"]
-    dock_results --> dock_poses["get_poses()\ndownloaded PoseSet"]
-
-    ml_run -.->|"start() raises: use run()"| blocked(["✗"])
-    dock_start -.->|"run() raises: use start()"| blocked
+    dock_start -->|" submits "| dock_wait["wait() / watch()"]
+    dock_start -.->|" run() raises "| blocked
+    dock_wait --> dock_results["get_results()<br/>DataFrame, from the platform"]
+    dock_results --> dock_poses["get_poses()<br/>downloaded PoseSet"]
 ```
 
 `get_results()` always returns a `pandas.DataFrame` regardless of method. On

--- a/docs/dd/tools/secondary-pharma.md
+++ b/docs/dd/tools/secondary-pharma.md
@@ -1,0 +1,127 @@
+# Secondary Pharmacology
+
+Score ligands against a baked secondary-pharmacology kinase panel (currently
+EGFR, BRAF, and SRC — the panel is expected to grow) with
+[`SecondaryPharmacology`](../ref/secondary_pharma.md).
+
+## Two execution modes on one class
+
+`SecondaryPharmacology` wraps two mutually-exclusive scoring paths, selected
+by `method` at construction:
+
+- `method="ligand-ml"` — served, synchronous XGBoost booster scoring. Use
+  [`run()`](../ref/secondary_pharma.md).
+- `method="docking"` (the default) — an async workflow. Use
+  [`start()`](../ref/secondary_pharma.md).
+
+`run()`, `start()`, and `watch()` are all available on every instance, but
+only the one matching `method` works — the others raise immediately, telling
+you which to call instead:
+
+```mermaid
+flowchart TD
+    ctor["SecondaryPharmacology(method=...)"]
+    ctor -->|"method='ligand-ml'"| ml_run["run()"]
+    ctor -->|"method='docking'"| dock_start["start()"]
+
+    ml_run --> ml_results["get_results()\nDataFrame, returned immediately"]
+
+    dock_start --> dock_wait["wait() / watch()"]
+    dock_wait --> dock_results["get_results()\nDataFrame, from the platform"]
+    dock_results --> dock_poses["get_poses()\ndownloaded PoseSet"]
+
+    ml_run -.->|"start() raises: use run()"| blocked(["✗"])
+    dock_start -.->|"run() raises: use start()"| blocked
+```
+
+`get_results()` always returns a `pandas.DataFrame` regardless of method. On
+the docking path, allow a moment after `wait()`/`watch()` completes — results
+land in the platform's data index rather than the immediate response, the
+same as [`Docking.get_results()`](../ref/docking.md).
+
+## Ligand-ML scoring
+
+```{.python notest}
+from deeporigin.drug_discovery import SecondaryPharmacology, Ligand
+
+ligand = Ligand.from_smiles("CCO")
+job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml")
+df = job.run()
+```
+
+`df` has one row per ligand × panel member, with `uniprot_id`, `gene_name`,
+and exactly one of `p_active` (classification) or `p_affinity` (regression,
+-log10 M) set per row.
+
+Restrict to a subset of the panel with `uniprots` (validated against the live
+tool definition's panel enum at construction):
+
+```{.python notest}
+job = SecondaryPharmacology(
+    ligands=[ligand],
+    method="ligand-ml",
+    uniprots=["P00533"],  # EGFR only
+)
+```
+
+## Docking
+
+```{.python notest}
+job = SecondaryPharmacology(ligands=[ligand], method="docking", effort=2)
+job.start()
+job.wait()               # or `await job.watch()` in a notebook
+df = job.get_results()
+```
+
+`df` has one row per docked pose, including `pose_score`, `binding_energy`,
+and `file_path`. To load and download the poses as a
+[`PoseSet`](../ref/pose.md) instead — for visualization, SDF export, or
+feeding into a downstream tool like `ABFE`:
+
+```{.python notest}
+poses = job.get_poses()
+```
+
+`effort` (1–5) is validated on both methods before submission, even though
+the tool only uses it for docking.
+
+## Self-test
+
+Both methods accept `self_test=True` (mutually exclusive with `ligands` —
+passing both raises), which scores a baked test ligand (gefitinib) against
+the full panel:
+
+```{.python notest}
+job = SecondaryPharmacology(self_test=True, method="ligand-ml")
+df = job.run()
+```
+
+On the ligand-ml path, this exercises the real mounted model volume, not a
+stub — useful as a quick end-to-end health check of the tool itself.
+
+!!! warning "Self-test has no results on the docking path"
+    The baked test ligand has no ligand id, so no panel poses are ever
+    published for it. Both `get_results()` and `get_poses()` raise —
+    use the ligand-ml path above for a self-test health check instead.
+
+## Working with existing runs
+
+```{.python notest}
+job = SecondaryPharmacology.from_id("<executionId>")
+job.sync()
+df = job.get_results()
+```
+
+`from_dto`/`from_id` restore `method`, `ligands`, `uniprots`, `effort`, and
+`self_test` from the stored execution inputs. A rehydrated instance's
+`uniprots` is read-only until `duplicate()`, which re-fetches the live tool
+definition.
+
+## Current limitations
+
+- The panel is small (3 kinases today) and only grows by tool version bump —
+  `uniprots` validation is against whatever panel the pinned `tool_version`
+  shipped with.
+- The docking workflow has no ligand batching (unlike `deeporigin.docking`'s
+  `batchSize`): it is a single Argo task with no fan-out, so a very large
+  ligand list runs as one job against a fixed resource/time budget.

--- a/src/drug_discovery/__init__.py
+++ b/src/drug_discovery/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     "StructureReportResult",
     "UniprotDiscovery",
     "UniprotDiscoveryCandidate",
+    "SecondaryPharmacology",
 ]
 
 DATA_DIR = files("deeporigin.data")
@@ -79,6 +80,10 @@ _LAZY_IMPORTS = {
     "Molprops": ("deeporigin.drug_discovery.molprops", "Molprops"),
     "Admet": ("deeporigin.drug_discovery.admet", "Admet"),
     "Metabolism": ("deeporigin.drug_discovery.metabolism", "Metabolism"),
+    "SecondaryPharmacology": (
+        "deeporigin.drug_discovery.secondary_pharma",
+        "SecondaryPharmacology",
+    ),
     "Protonation": ("deeporigin.drug_discovery.protonation", "Protonation"),
     "Konnektor": ("deeporigin.drug_discovery.konnektor", "Konnektor"),
     "KonnektorResult": ("deeporigin.drug_discovery.konnektor", "KonnektorResult"),

--- a/src/drug_discovery/secondary_pharma.py
+++ b/src/drug_discovery/secondary_pharma.py
@@ -421,7 +421,12 @@ class SecondaryPharmacology(
             parts.append("  uniprots=full panel,")
         if self._method == "docking":
             parts.append(f"  effort={self.effort},")
-        parts.append(")")
+        hint = (
+            "call start() to execute asynchronously"
+            if self._method == "docking"
+            else "call run() to execute synchronously"
+        )
+        parts.append(f")  # {hint}")
         return "\n".join(parts)
 
     def _fetch_definition_uniprots(self) -> list[str]:

--- a/src/drug_discovery/secondary_pharma.py
+++ b/src/drug_discovery/secondary_pharma.py
@@ -61,10 +61,6 @@ _UNIPROTS_ENUM_MISSING = (
 )
 
 
-# ponytail: duplicates Admet's definition-enum fetch/validate pattern almost
-# verbatim (see _endpoints_from_definition / _validate_admet_properties in
-# admet.py). Not extracted into a shared helper in this PR -- noted in the PR
-# description as a follow-up; extract once a third caller needs the same shape.
 def _uniprots_from_definition(definition: dict[str, Any]) -> list[str]:
     """Return the panel's UniProt accessions from a platform tool definition.
 

--- a/src/drug_discovery/secondary_pharma.py
+++ b/src/drug_discovery/secondary_pharma.py
@@ -1,0 +1,774 @@
+"""SecondaryPharmacology -- score ligands against a baked kinase panel.
+
+Backed by the platform tool ``deeporigin.secondary-pharma``, which supports two
+mutually exclusive scoring methods selected at construction:
+
+- ``"ligand-ml"`` -- served, synchronous XGBoost booster scoring. Use :meth:`run`.
+- ``"docking"`` -- Argo workflow, asynchronous only. Use :meth:`start` (and
+  :meth:`watch` in Jupyter).
+
+The tool schema has no ``inputs.sync`` field (unlike ``deeporigin.docking``), so
+``method`` alone determines execution modality -- there is no unified blocking/
+non-blocking call across both paths. :meth:`get_results` always returns a
+:class:`pandas.DataFrame` regardless of method (method-aware columns), but the
+two paths load from different places: ``ligand-ml`` is served/sync, so results
+come back in the same response's ``jobOutputs``; ``docking`` is an async Argo
+workflow, so results are only ever persisted to result-explorer (``jobOutputs``
+on a polled execution is empty) -- same reason ``Docking.get_results()`` tries
+result-explorer before ``jobOutputs``. On the docking path, :meth:`get_poses`
+is a convenience that turns the same rows into a downloaded
+:class:`~deeporigin.drug_discovery.structures.pose.PoseSet`.
+
+Usage::
+
+    from deeporigin.drug_discovery import SecondaryPharmacology, Ligand
+
+    ligand = Ligand.from_smiles("CCO")
+
+    ml = SecondaryPharmacology(ligands=[ligand], method="ligand-ml")
+    df = ml.run()
+
+    dock = SecondaryPharmacology(ligands=[ligand], method="docking", effort=2)
+    dock.start()
+    dock.wait()
+    df = dock.get_results()
+    poses = dock.get_poses()
+"""
+
+from __future__ import annotations
+
+from asyncio import Task
+from typing import Any, Literal, Self
+
+from beartype import beartype
+import pandas as pd
+
+from deeporigin.drug_discovery.execution import Execution, _execution_outputs_dict
+from deeporigin.drug_discovery.execution_mixins import (
+    AsyncExecutableMixin,
+    SyncExecutableMixin,
+)
+from deeporigin.drug_discovery.notebook_watch_mixin import NotebookWatchMixin
+from deeporigin.drug_discovery.structures.ligand import Ligand, LigandSet
+from deeporigin.drug_discovery.structures.pose import PoseSet
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.platform.client import DeepOriginClient
+from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
+
+_UNIPROTS_ENUM_MISSING = (
+    "SecondaryPharmacology tool definition is missing a non-empty uniprots enum "
+    "(inputs.properties.uniprots.items.enum)."
+)
+
+
+# ponytail: duplicates Admet's definition-enum fetch/validate pattern almost
+# verbatim (see _endpoints_from_definition / _validate_admet_properties in
+# admet.py). Not extracted into a shared helper in this PR -- noted in the PR
+# description as a follow-up; extract once a third caller needs the same shape.
+def _uniprots_from_definition(definition: dict[str, Any]) -> list[str]:
+    """Return the panel's UniProt accessions from a platform tool definition.
+
+    Reads JSON Schema ``inputs.properties.uniprots.items.enum``.
+
+    Args:
+        definition: Tool definition dict from ``client.tools.get``.
+
+    Returns:
+        UniProt accessions in definition order.
+
+    Raises:
+        ValueError: If the enum is missing, empty, or not a list of strings.
+    """
+    inputs = definition.get("inputs")
+    if not isinstance(inputs, dict):
+        raise ValueError(_UNIPROTS_ENUM_MISSING)
+    schema_properties = inputs.get("properties")
+    if not isinstance(schema_properties, dict):
+        raise ValueError(_UNIPROTS_ENUM_MISSING)
+    uniprots_field = schema_properties.get("uniprots")
+    if not isinstance(uniprots_field, dict):
+        raise ValueError(_UNIPROTS_ENUM_MISSING)
+    items = uniprots_field.get("items")
+    if not isinstance(items, dict):
+        raise ValueError(_UNIPROTS_ENUM_MISSING)
+    enum = items.get("enum")
+    if not isinstance(enum, list) or not enum:
+        raise ValueError(_UNIPROTS_ENUM_MISSING)
+    names = [item for item in enum if isinstance(item, str) and item]
+    if len(names) != len(enum) or len(set(names)) != len(names):
+        raise ValueError(_UNIPROTS_ENUM_MISSING)
+    return list(names)
+
+
+def _validate_uniprots(
+    uniprots: list[str],
+    *,
+    allowed: frozenset[str],
+) -> list[str]:
+    """Return a copy of *uniprots* or raise if the selection is invalid."""
+    if not uniprots:
+        raise ValueError("uniprots must be non-empty when provided.")
+    if len(uniprots) != len(set(uniprots)):
+        raise ValueError("uniprots must not contain duplicates.")
+    unknown = set(uniprots) - allowed
+    if unknown:
+        raise ValueError(
+            f"Unknown UniProt accessions {sorted(unknown)}. Allowed: {sorted(allowed)}"
+        )
+    return list(uniprots)
+
+
+def _docking_ligand_row(lig: Ligand) -> dict[str, Any]:
+    """Build one ligand entry for the docking path (id and smiles only).
+
+    Assumes ``lig.id`` is already set -- call ``self.ligands`` synced (see
+    :meth:`SecondaryPharmacology._ensure_platform_inputs`) before this runs.
+    Mirrors ``Docking._ligand_tool_input_row`` exactly.
+    """
+    return {"id": lig.id, "smiles": lig.smiles}
+
+
+def _ligand_ml_ligand_rows(ligands: list[Ligand]) -> list[dict[str, Any]]:
+    """Build ligand entries for the ligand-ml path (served, never synced).
+
+    Falls back to the list index as ``id`` when a ligand has none yet -- ligands
+    are not synced/mutated for this path, mirroring ``Admet._make_inputs``.
+    """
+    rows: list[dict[str, Any]] = []
+    for idx, lig in enumerate(ligands):
+        row: dict[str, Any] = {"smiles": lig.smiles or ""}
+        row["id"] = lig.id if lig.id is not None else str(idx)
+        rows.append(row)
+    return rows
+
+
+def _ligands_from_inputs(inputs: dict[str, Any]) -> list[Ligand]:
+    """Rebuild ligands from stored secondary-pharma ``userInputs``.
+
+    Returns an empty list (rather than raising, unlike ``Admet``'s equivalent)
+    when ``ligands`` is absent -- a valid, expected shape for ``self_test`` runs.
+    """
+    raw = inputs.get("ligands")
+    if not isinstance(raw, list) or not raw:
+        return []
+    ligands: list[Ligand] = []
+    for idx, row in enumerate(raw):
+        if not isinstance(row, dict):
+            raise ValueError(
+                f"Cannot rehydrate SecondaryPharmacology: ligands[{idx}] is not an object."
+            )
+        smiles = row.get("smiles")
+        if not smiles or not isinstance(smiles, str):
+            raise ValueError(
+                f"Cannot rehydrate SecondaryPharmacology: ligands[{idx}] has no SMILES."
+            )
+        ligand = Ligand.from_smiles(smiles)
+        if row.get("id") is not None:
+            ligand.id = str(row["id"])
+        ligands.append(ligand)
+    return ligands
+
+
+# Result-explorer stores this table's rows under result_type="panelpose" --
+# lowercased PanelPose (x-data-type), no separator. Same convention as the
+# named result_type constants in platform/results.py (e.g. "preparedsystem"
+# for PreparedSystem, "abferesult" for ABFEResult, "metabolismsite" for
+# MetabolismSite) -- confirmed there rather than assumed here.
+_PANEL_POSE_RESULT_TYPE = "panelpose"
+
+
+def _load_panel_pose_rows(
+    exec_id: str,
+    *,
+    client: DeepOriginClient,
+    dto: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Load ``panel_poses`` rows from result-explorer, falling back to ``jobOutputs``.
+
+    Mirrors :func:`~deeporigin.drug_discovery.docking_common.load_docking_poses_from_execution`'s
+    shape: the docking path is an async Argo workflow, which usually persists
+    rows only in result-explorer, not in a polled execution's ``jobOutputs``.
+
+    Args:
+        exec_id: Platform execution ID.
+        client: API client.
+        dto: Optional execution payload, consulted only if result-explorer
+            has no rows yet (avoids an extra GET when one is already at hand).
+
+    Returns:
+        Flattened ``panel_poses`` row dicts (each result-explorer record's
+        nested ``data`` merged with its ``id``).
+
+    Raises:
+        DeepOriginException: If no rows could be loaded from either source.
+    """
+    errors: list[str] = []
+
+    try:
+        response = client.results.get(
+            compute_job_id=exec_id,
+            result_type=_PANEL_POSE_RESULT_TYPE,
+            limit=None,
+        )
+        records = [rec for rec in response.get("data", []) if isinstance(rec, dict)]
+        rows: list[dict[str, Any]] = []
+        for rec in records:
+            data = rec.get("data")
+            if not isinstance(data, dict):
+                continue
+            row = dict(data)
+            if rec.get("id") is not None:
+                row["id"] = str(rec["id"])
+            rows.append(row)
+        if rows:
+            return rows
+        errors.append("result-explorer returned zero panelpose rows")
+    except Exception as exc:
+        errors.append(f"result-explorer: {exc}")
+
+    try:
+        if dto is None:
+            dto = client.executions.get(exec_id)  # ty:ignore[unresolved-attribute]
+        outputs = _execution_outputs_dict(dto)
+        raw = outputs.get("panel_poses")
+        rows = (
+            [dict(item) for item in raw if isinstance(item, dict)]
+            if isinstance(raw, list)
+            else []
+        )
+        if rows:
+            return rows
+        errors.append("jobOutputs.panel_poses is empty")
+    except Exception as exc:
+        errors.append(f"jobOutputs: {exc}")
+
+    detail = "; ".join(errors)
+    raise DeepOriginException(
+        title="SecondaryPharmacology results missing",
+        message=(
+            f"No panel_poses rows could be loaded for execution {exec_id!r}. {detail}."
+        ),
+    )
+
+
+def _secondary_pharma_default_name(
+    *,
+    method: str,
+    ligands: list[Ligand],
+    uniprots: list[str] | tuple[str, ...] | None,
+    self_test: bool,
+) -> str:
+    """Build a short human-readable label, e.g. ``SecondaryPharma (docking): 12 ligands vs full panel``."""
+    if self_test:
+        target = "self-test"
+    else:
+        n = len(ligands)
+        target = f"{n} ligand" + ("" if n == 1 else "s")
+    if uniprots:
+        n_panel = len(uniprots)
+        panel = f"{n_panel} panel target" + ("" if n_panel == 1 else "s")
+    else:
+        panel = "full panel"
+    return f"SecondaryPharma ({method}): {target} vs {panel}"
+
+
+class SecondaryPharmacology(
+    Execution, SyncExecutableMixin, AsyncExecutableMixin, NotebookWatchMixin
+):
+    """Score ligands against a baked secondary-pharmacology kinase panel.
+
+    Attributes:
+        ligands: Ligands to score. Empty only when :attr:`self_test` is ``True``.
+        method: Scoring path for this instance -- ``"docking"`` (async workflow,
+            use :meth:`start`) or ``"ligand-ml"`` (served, use :meth:`run`).
+        uniprots: Panel accessions to restrict scoring to, or ``None`` for the
+            whole panel. Validated against the live tool definition's enum.
+        effort: Docking effort level (1 = fastest, 5 = most thorough). Ignored
+            on the ligand-ml path.
+        self_test: When ``True``, runs the selected method against the full
+            panel with a baked test ligand and ignores :attr:`ligands`.
+    """
+
+    tool_key: str = TOOL_KEYS_AND_VERSIONS["secondary_pharma"]["tool_key"]
+    effort: int = 1
+
+    @beartype
+    def __init__(
+        self,
+        *,
+        ligands: list[Ligand] | LigandSet | None = None,
+        method: Literal["docking", "ligand-ml"] = "docking",
+        uniprots: list[str] | None = None,
+        effort: int = 1,
+        self_test: bool = False,
+        tool_version: str = TOOL_KEYS_AND_VERSIONS["secondary_pharma"]["tool_version"],
+        client: DeepOriginClient | None = None,
+        name: str | None = None,
+    ) -> None:
+        """Configure a secondary-pharmacology panel run for one or more ligands.
+
+        Args:
+            ligands: Ligands to score. Required unless ``self_test=True``.
+            method: ``"docking"`` (async workflow) or ``"ligand-ml"`` (served,
+                synchronous). Determines whether :meth:`run` or :meth:`start`
+                is valid for this instance.
+            uniprots: Panel accessions to restrict to. Validated against the
+                live tool definition. ``None`` or empty scores the whole panel.
+            effort: Docking effort level (1-5). Ignored on the ligand-ml path.
+            self_test: When ``True``, ``ligands`` is not required; the platform
+                runs the selected method against the full panel with a baked
+                test ligand.
+            tool_version: Platform tool version. Defaults to ``"latest"``.
+            client: Optional API client.
+            name: Optional execution label. When omitted, generated from
+                ``method``, ligand count (or ``self_test``), and ``uniprots``.
+
+        Raises:
+            ValueError: If ``ligands`` is empty/omitted and ``self_test`` is
+                ``False``, if ``self_test`` is ``True`` and ``ligands`` is
+                also given, or if ``uniprots`` names accessions outside the
+                live panel.
+        """
+        if isinstance(ligands, LigandSet):
+            resolved_ligands: list[Ligand] = list(ligands.ligands)
+        elif ligands is not None:
+            resolved_ligands = list(ligands)
+        else:
+            resolved_ligands = []
+
+        if not resolved_ligands and not self_test:
+            raise ValueError("ligands is required unless self_test=True.")
+        if resolved_ligands and self_test:
+            raise ValueError(
+                "ligands is ignored when self_test=True (the platform scores "
+                "a baked test ligand instead) -- pass one or the other, not both."
+            )
+
+        super().__init__(client=client)
+        self.tool_version = tool_version
+        self.effort = effort
+        self._method = method
+        self._self_test = self_test
+        self._ligands = resolved_ligands
+
+        allowed = self._fetch_definition_uniprots()
+        self._allowed_uniprots: frozenset[str] | None = frozenset(allowed)
+        self._uniprots: list[str] | tuple[str, ...] | None = (
+            _validate_uniprots(uniprots, allowed=self._allowed_uniprots)
+            if uniprots
+            else None
+        )
+        self.name = (
+            name
+            if name is not None
+            else _secondary_pharma_default_name(
+                method=self._method,
+                ligands=self._ligands,
+                uniprots=self._uniprots,
+                self_test=self._self_test,
+            )
+        )
+
+    @property
+    def ligands(self) -> list[Ligand]:
+        """Ligands targeted by this run (read-only)."""
+        return self._ligands
+
+    @property
+    def method(self) -> str:
+        """Scoring path for this instance (``"docking"`` or ``"ligand-ml"``)."""
+        return self._method
+
+    @property
+    def self_test(self) -> bool:
+        """Whether this run scores the baked test ligand against the full panel."""
+        return self._self_test
+
+    @property
+    def uniprots(self) -> list[str] | tuple[str, ...] | None:
+        """Panel accessions this run is restricted to, or ``None`` for the whole panel.
+
+        A mutable list on a draft instance. After an execution ``id`` is set, a
+        tuple. ``None`` when unset or a rehydrated execution omitted the field.
+        """
+        return self._uniprots
+
+    @uniprots.setter
+    def uniprots(self, value: list[str] | None) -> None:
+        """Replace the draft accession list, or clear it with ``None``."""
+        if getattr(self, "_id", None) is not None:
+            raise AttributeError(
+                "cannot assign to 'uniprots': execution id is already set"
+            )
+        if value is None:
+            self._uniprots = None
+            return
+        allowed = getattr(self, "_allowed_uniprots", None)
+        if allowed is None:
+            raise ValueError(
+                "uniprots can only be set on a SecondaryPharmacology that "
+                "loaded a tool definition."
+            )
+        self._uniprots = _validate_uniprots(value, allowed=allowed)
+
+    def __repr__(self) -> str:
+        """Return a concise summary of this secondary-pharma execution's configuration."""
+        parts = ["SecondaryPharmacology("]
+        parts.append(f"  method={self._method!r},")
+        if self._self_test:
+            parts.append("  self_test=True,")
+        else:
+            parts.append(f"  ligands={len(self._ligands)},")
+        if self._uniprots:
+            parts.append(f"  uniprots={list(self._uniprots)!r},")
+        else:
+            parts.append("  uniprots=full panel,")
+        if self._method == "docking":
+            parts.append(f"  effort={self.effort},")
+        parts.append(")")
+        return "\n".join(parts)
+
+    def _fetch_definition_uniprots(self) -> list[str]:
+        """Return panel accessions from the live secondary-pharma tool definition."""
+        if self.client.tools is None:
+            raise RuntimeError("DeepOriginClient has no tools API")
+        definition = self.client.tools.get(
+            tool_key=self.tool_key,
+            tool_version=self.tool_version,
+        )
+        return _uniprots_from_definition(definition)
+
+    def update_from_dto(self, dto: dict[str, Any]) -> None:
+        """Apply execution fields from ``dto`` and freeze ``uniprots``."""
+        super().update_from_dto(dto)
+        uniprots = getattr(self, "_uniprots", None)
+        if self._id is not None and isinstance(uniprots, list):
+            self._uniprots = tuple(uniprots)
+
+    def _ensure_method(self, expected: str, *, alternative_call: str) -> None:
+        """Raise if this instance's :attr:`method` does not match *expected*."""
+        if self._method != expected:
+            raise ValueError(
+                f"method={self._method!r}: use {alternative_call}() instead."
+            )
+
+    def _ensure_platform_inputs(self) -> None:
+        """Sync ligands to the data platform for the docking path.
+
+        Only the docking path is a workflow that needs persisted ligand ids
+        (mirrors ``Docking._ensure_platform_inputs``); the ligand-ml path is
+        served directly from SMILES like ``Admet`` and is never synced.
+        """
+        LigandSet(ligands=self._ligands).sync(lazy=True, client=self.client)
+
+    def _validate_effort(self) -> None:
+        """Raise if :attr:`effort` is outside 1-5.
+
+        The schema declares ``effort`` as a plain top-level input with no
+        conditional relaxation for the ligand-ml path, so an out-of-range
+        value is rejected there too, even though the tool ignores it once
+        it's within range -- checked on both :meth:`run` and :meth:`start`.
+        """
+        if not 1 <= self.effort <= 5:
+            raise DeepOriginException(
+                f"effort must be between 1 and 5 inclusive, got {self.effort}"
+            )
+
+    def _ensure_uniprots_for_run(self) -> None:
+        """Re-validate ``uniprots`` immediately before submission.
+
+        The :attr:`uniprots` getter returns the live list, so an in-place
+        edit (``job.uniprots.append(...)``) bypasses the setter's
+        validation; this re-checks right before the payload is built,
+        mirroring ``Admet._ensure_properties_for_run``.
+        """
+        if self._uniprots is None:
+            return
+        values = list(self._uniprots)
+        allowed = getattr(self, "_allowed_uniprots", None)
+        if allowed is not None:
+            self._uniprots = _validate_uniprots(values, allowed=allowed)
+            return
+        if not values:
+            raise ValueError("uniprots must be non-empty when provided.")
+        if len(values) != len(set(values)):
+            raise ValueError("uniprots must not contain duplicates.")
+
+    def _make_inputs(self) -> dict[str, Any]:
+        """Build tool ``inputs`` matching the secondary-pharma schema."""
+        inputs: dict[str, Any] = {
+            "methods": [self._method],
+            "effort": self.effort,
+            "self_test": self._self_test,
+        }
+        if self._ligands:
+            if self._method == "docking":
+                inputs["ligands"] = [_docking_ligand_row(lig) for lig in self._ligands]
+            else:
+                inputs["ligands"] = _ligand_ml_ligand_rows(self._ligands)
+        if self._uniprots:
+            inputs["uniprots"] = list(self._uniprots)
+        return inputs
+
+    def _make_payload(
+        self,
+        *,
+        approve_amount: int | None,
+        sync: bool,
+    ) -> dict[str, Any]:
+        """Build the body dict for ``client.executions.create``.
+
+        No ``batchSize``: unlike ``deeporigin.docking``, this tool's Argo
+        workflow (``tools/secondary-pharma/workflow/workflow.yaml``) is a
+        single DAG task with no ligand fan-out -- there is nothing on the
+        platform side to batch into today.
+        """
+        payload: dict[str, Any] = {
+            "inputs": self._make_inputs(),
+            "outputs": {},
+            "metadata": {},
+            "sync": sync,
+        }
+        if self.name is not None:
+            payload["name"] = self.name
+        if approve_amount is not None:
+            payload["approveAmount"] = approve_amount
+        return payload
+
+    @beartype
+    def run(
+        self,
+        *,
+        quote: bool = False,
+        approve_amount: int | None = None,
+    ) -> pd.DataFrame | SecondaryPharmacology:
+        """Execute the ligand-ml path synchronously and return predictions.
+
+        Valid only when :attr:`method` is ``"ligand-ml"``; use :meth:`start`
+        for the docking path.
+
+        With ``quote=True`` (or ``approve_amount=0``), requests a cost
+        estimate only, updates execution fields from the platform DTO, and
+        returns ``self`` without running inference.
+
+        Args:
+            quote: Shorthand for ``approve_amount=0``.
+            approve_amount: Spend cap forwarded as ``approveAmount``.
+
+        Returns:
+            A :class:`pandas.DataFrame` of ligand-ml predictions, or ``self``
+            when quoting.
+
+        Raises:
+            ValueError: If :attr:`method` is not ``"ligand-ml"``, or if
+                ``uniprots`` was mutated in place into an invalid selection.
+            DeepOriginException: If ``effort`` is outside 1-5, or the
+                execution did not complete successfully.
+        """
+        self._ensure_method("ligand-ml", alternative_call="start")
+        self._validate_effort()
+        self._ensure_uniprots_for_run()
+        resolved_amount = 0 if quote else approve_amount
+        sync = resolved_amount is None
+        dto = self._create_execution(
+            data=self._make_payload(approve_amount=resolved_amount, sync=sync),
+        )
+        self.update_from_dto(dto)
+
+        if quote or resolved_amount == 0:
+            return self
+
+        if not is_success_status(self.status):
+            raise DeepOriginException(
+                title="SecondaryPharmacology run did not succeed",
+                message=(f"Execution {self.id!r} ended in {self.status!r} state."),
+            )
+
+        return self.get_results(dto)
+
+    def _start_impl(self, *, approve_amount: int | None = None, **kwargs: Any) -> None:
+        """Submit the docking path as a persisted async execution."""
+        self._ensure_method("docking", alternative_call="run")
+        self._validate_effort()
+        self._ensure_uniprots_for_run()
+        self._ensure_platform_inputs()
+        payload = self._make_payload(approve_amount=approve_amount, sync=False)
+        execution_dto = self._create_execution(data=payload)
+        self._id = execution_dto.get("executionId")
+        self.status = execution_dto.get("status")
+
+    @beartype
+    async def watch(
+        self,
+        *,
+        interval: float = 5.0,
+        blocking: bool = False,
+    ) -> Task | None:
+        """Live notebook updates for the docking path only.
+
+        Valid only when :attr:`method` is ``"docking"`` -- the ligand-ml path
+        is synchronous (:meth:`run` blocks until done), so there is never an
+        in-flight async job to poll.
+
+        See :meth:`~deeporigin.drug_discovery.notebook_watch_mixin.NotebookWatchMixin.watch`
+        for the full parameter/return contract.
+
+        Raises:
+            ValueError: If :attr:`method` is not ``"docking"``.
+        """
+        self._ensure_method("docking", alternative_call="run")
+        return await super().watch(interval=interval, blocking=blocking)
+
+    @beartype
+    def get_results(self, dto: dict[str, Any] | None = None) -> pd.DataFrame:
+        """Return this execution's results as a :class:`pandas.DataFrame`.
+
+        Method-aware, and the two paths load from different places:
+
+        - ``ligand-ml`` is served/sync, so ``jobOutputs`` is populated in the
+          same response that completed the run -- read directly, like
+          :meth:`Admet.get_results <deeporigin.drug_discovery.admet.Admet.get_results>`.
+        - ``docking`` is an async Argo workflow with no synchronous response
+          to embed results into, so it only ever persists rows to
+          result-explorer; ``jobOutputs`` on a polled execution is empty.
+          Loaded via :func:`_load_panel_pose_rows`, mirroring
+          :func:`~deeporigin.drug_discovery.docking_common.load_docking_poses_from_execution`'s
+          result-explorer-first, ``jobOutputs``-fallback shape.
+
+        The docking-path DataFrame includes ``file_path`` for each pose's SDF;
+        use :meth:`get_poses` to load them as a downloaded
+        :class:`~deeporigin.drug_discovery.structures.pose.PoseSet` instead.
+
+        Args:
+            dto: Optional execution payload (``executions.create`` /
+                ``executions.get``). On the ligand-ml path, used directly
+                instead of an extra GET. On the docking path, only consulted
+                as a fallback if result-explorer has no rows yet.
+
+        Returns:
+            A DataFrame of ``ligand_ml_predictions`` or ``panel_poses`` rows.
+
+        Raises:
+            ValueError: If :attr:`id` is unset and ``dto`` is omitted.
+            DeepOriginException: If no rows could be loaded.
+        """
+        if self._method == "ligand-ml":
+            if dto is None:
+                exec_id = self._ensure_id()
+                dto = self.client.executions.get(exec_id)  # ty:ignore[unresolved-attribute]
+            outputs = _execution_outputs_dict(dto)
+            rows = outputs.get("ligand_ml_predictions")
+            if not isinstance(rows, list) or not rows:
+                raise DeepOriginException(
+                    title="SecondaryPharmacology results missing",
+                    message=(
+                        f"Execution {self.id!r} returned no "
+                        "'ligand_ml_predictions' rows in jobOutputs."
+                    ),
+                )
+            return pd.DataFrame([row for row in rows if isinstance(row, dict)])
+
+        exec_id = self._ensure_id()
+        rows = _load_panel_pose_rows(exec_id, client=self.client, dto=dto)
+        return pd.DataFrame(rows)
+
+    def get_poses(self, *, dto: dict[str, Any] | None = None) -> PoseSet:
+        """Load and download docking-path panel poses as a :class:`PoseSet`.
+
+        Valid only when :attr:`method` is ``"docking"``. Loads the same
+        ``panel_poses`` rows as :meth:`get_results` (result-explorer first,
+        ``jobOutputs`` fallback -- see :func:`_load_panel_pose_rows`) and
+        builds poses via
+        :meth:`Pose.from_json <deeporigin.drug_discovery.structures.pose.Pose.from_json>`,
+        which is generic over row dicts and not tied to the platform's
+        ``result_type="pose"`` result group that ``panel_poses`` rows do not
+        belong to (they are ``result_type="panelpose"``), then downloads the
+        SDFs -- matching
+        :meth:`Docking.get_poses <deeporigin.drug_discovery.docking.Docking.get_poses>`'s
+        behavior exactly.
+
+        Not available for a ``self_test`` run: the platform's baked test
+        ligand has no ligand id, so the platform publishes no panel-pose
+        rows for it at all (unidentified rows are filtered before
+        publishing) -- there is nothing for :meth:`get_results` to return
+        either in this case, so it isn't a usable fallback here.
+
+        Args:
+            dto: Optional execution payload, forwarded to :func:`_load_panel_pose_rows`.
+
+        Returns:
+            A :class:`PoseSet` of downloaded docked panel poses.
+
+        Raises:
+            ValueError: If :attr:`method` is not ``"docking"``, or if this is
+                a ``self_test`` run.
+        """
+        self._ensure_method("docking", alternative_call="get_results")
+        if self._self_test:
+            raise ValueError(
+                "get_poses() is not available for self_test runs: the "
+                "platform's baked test ligand has no ligand id, so no panel "
+                "poses are published for it (get_results() has nothing to "
+                "return either, for the same reason)."
+            )
+        exec_id = self._ensure_id()
+        rows = _load_panel_pose_rows(exec_id, client=self.client, dto=dto)
+        poses = PoseSet.from_json(rows, client=self.client)
+        poses.download(client=self.client, lazy=True)
+        return poses
+
+    @classmethod
+    def from_dto(
+        cls,
+        dto: dict[str, Any],
+        *,
+        client: DeepOriginClient | None = None,
+    ) -> Self:
+        """Construct a ``SecondaryPharmacology`` from a tools execution DTO.
+
+        Restores ligands, method, uniprots, effort, and self_test from
+        ``userInputs``. Does not fetch the live tool definition, so a
+        rehydrated instance's ``uniprots`` is read-only until :meth:`duplicate`
+        is called.
+
+        Args:
+            dto: Execution payload (same shape as ``client.executions.get``).
+            client: Optional API client. Uses the default if not provided.
+
+        Returns:
+            A ``SecondaryPharmacology`` with ``id``, lifecycle fields, and
+            domain inputs set.
+        """
+        instance = super().from_dto(dto, client=client)
+        inputs: dict[str, Any] = dto.get("userInputs") or dto.get("inputs") or {}
+        instance._ligands = _ligands_from_inputs(inputs)
+        methods = inputs.get("methods")
+        instance._method = (
+            methods[0] if isinstance(methods, list) and methods else "docking"
+        )
+        instance._self_test = bool(inputs.get("self_test", False))
+        raw_effort = inputs.get("effort")
+        instance.effort = int(raw_effort) if raw_effort is not None else cls.effort
+        raw_uniprots = inputs.get("uniprots")
+        instance._uniprots = (
+            tuple(raw_uniprots)
+            if isinstance(raw_uniprots, list) and raw_uniprots
+            else None
+        )
+        instance._allowed_uniprots = None
+        return instance
+
+    def duplicate(self, *, client: DeepOriginClient | None = None) -> Self:
+        """Copy configuration into a new draft with a writable ``uniprots``.
+
+        ``from_dto`` does not fetch the tool definition, so a rehydrated
+        instance has no allowlist. Fetch it here so the draft can assign
+        ``uniprots`` like a constructor-built instance.
+        """
+        new = super().duplicate(client=client)
+        if isinstance(getattr(new, "_uniprots", None), tuple):
+            new._uniprots = list(new._uniprots)
+        if getattr(new, "_allowed_uniprots", None) is None:
+            allowed = new._fetch_definition_uniprots()
+            new._allowed_uniprots = frozenset(allowed)
+        return new

--- a/src/platform/constants.py
+++ b/src/platform/constants.py
@@ -166,4 +166,8 @@ TOOL_KEYS_AND_VERSIONS: dict[str, dict[str, str]] = {
         "tool_key": "deeporigin.import-dataset",
         "tool_version": "latest",
     },
+    "secondary_pharma": {
+        "tool_key": "deeporigin.secondary-pharma",
+        "tool_version": "latest",
+    },
 }

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -116,6 +116,26 @@ MOCK_ADMET_ENDPOINTS: tuple[str, ...] = (
     "LC50FM_regression",
 )
 
+# Panel enum for mock ``deeporigin.secondary-pharma`` (tool definition uniprots
+# enum). Real accessions/gene names/PDB ids from
+# tools/secondary-pharma/panel/manifest.json.
+MOCK_SECONDARY_PHARMA_PANEL: tuple[tuple[str, str, str], ...] = (
+    ("P00533", "EGFR", "1M17"),
+    ("P15056", "BRAF", "2FB8"),
+    ("P12931", "SRC", "1YOM"),
+)
+
+# Baked self_test ligand (gefitinib), matching the real tool's description.
+_MOCK_SECONDARY_PHARMA_SELF_TEST_SMILES = (
+    "COc1cc2ncnc(Nc3ccc(F)c(Cl)c3)c2cc1OCCCN1CCOCC1"
+)
+
+# Fixed remote path for mock panel-pose SDFs. Real content is uploaded by
+# whichever test exercises the docking path's get_poses() download step
+# (tests/test_secondary_pharma.py); every synthesized panel_poses row points
+# here so PoseSet.download() has something real to fetch.
+MOCK_SECONDARY_PHARMA_POSE_SDF_PATH = "testing/mock-secondary-pharma-pose.sdf"
+
 
 def _synthesize_structure_report_row(
     *,
@@ -717,6 +737,70 @@ def _synthesize_admet_prediction_row(
     return row
 
 
+def _synthesize_secondary_pharma_ligand_ml_row(
+    *, smiles: str, ligand_id: str, uniprot_id: str, gene_name: str
+) -> dict[str, Any]:
+    """Build a synthetic ligand-ml prediction row for one ligand x panel member.
+
+    Alternates classification/regression by a stable hash of the pair (rather
+    than always picking one), matching the schema's "exactly one of p_active /
+    p_affinity is set per row" contract.
+    """
+    seed = f"{smiles or ligand_id}:{uniprot_id}"
+    is_classification = int(_stable_unit_float(seed, "kind") * 2) == 0
+    row: dict[str, Any] = {
+        "ligand_id": ligand_id,
+        "uniprot_id": uniprot_id,
+        "gene_name": gene_name,
+        "ligand_smiles": smiles,
+        "type": "Enzyme (kinase)",
+        "p_active": round(_stable_unit_float(seed, "active"), 6)
+        if is_classification
+        else None,
+        "p_affinity": None
+        if is_classification
+        else _stable_log_value(seed, "affinity", low=4.0, high=10.0),
+    }
+    return row
+
+
+def _synthesize_secondary_pharma_panel_pose_row(
+    *,
+    ligand_id: str,
+    smiles: str,
+    uniprot_id: str,
+    gene_name: str,
+    pdb_id: str,
+    effort: int,
+) -> dict[str, Any]:
+    """Build a synthetic panel_poses row for one ligand x panel member (docking path).
+
+    ``file_path`` always points at ``MOCK_SECONDARY_PHARMA_POSE_SDF_PATH`` --
+    real content for that path is uploaded by whichever test needs a real
+    ``get_poses()`` download, not synthesized per row.
+    """
+    seed = f"{smiles or ligand_id}:{uniprot_id}"
+    return {
+        "best_pose": True,
+        "binding_energy": _stable_log_value(
+            seed, "binding_energy", low=-12.0, high=-4.0
+        ),
+        "box_size_x": 27.0,
+        "box_size_y": 27.0,
+        "box_size_z": 27.0,
+        "effort": effort,
+        "file_path": MOCK_SECONDARY_PHARMA_POSE_SDF_PATH,
+        "gene_name": gene_name,
+        "ligand_id": ligand_id,
+        "ligand_smiles": smiles,
+        "pdb_id": pdb_id,
+        "pocket_center": [0.0, 0.0, 0.0],
+        "pose_score": round(_stable_unit_float(seed, "pose_score"), 6),
+        "type": "Enzyme (kinase)",
+        "uniprot_id": uniprot_id,
+    }
+
+
 def _synthesize_metabolism_outputs(
     *, smiles: str, ligand_id: str | None
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -975,6 +1059,8 @@ def create_tools_router(
                 _inject_patent_tool_execution_results(execution)
             if tool_key == "deeporigin.metabolism":
                 _inject_metabolism_tool_execution_results(execution)
+            if tool_key == "deeporigin.secondary-pharma":
+                _inject_secondary_pharma_docking_tool_execution_results(execution)
             progress_reports = _load_progress_reports(tool_key)
             if progress_reports:
                 final_report = progress_reports[-1]
@@ -1359,6 +1445,199 @@ def create_tools_router(
             ],
         }
         return execution
+
+    def _build_secondary_pharma_ligand_ml_execution(
+        *, org_key: str, tool_key: str, tool_version: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build a synchronous ``deeporigin.secondary-pharma`` (ligand-ml) execution DTO."""
+
+        execution = _create_blocking_run_dto(
+            org_key=org_key,
+            tool_key=tool_key,
+            tool_version=tool_version,
+            body=body,
+        )
+
+        inputs = body.get("inputs", {}) or {}
+        if inputs.get("self_test"):
+            ligands_in: list[dict[str, Any]] = [
+                {
+                    "id": "self-test-gefitinib",
+                    "smiles": _MOCK_SECONDARY_PHARMA_SELF_TEST_SMILES,
+                }
+            ]
+        else:
+            ligands_in = inputs.get("ligands") or []
+
+        requested_uniprots = inputs.get("uniprots") or None
+        panel = [
+            (accession, gene, pdb_id)
+            for accession, gene, pdb_id in MOCK_SECONDARY_PHARMA_PANEL
+            if requested_uniprots is None or accession in requested_uniprots
+        ]
+
+        rows: list[dict[str, Any]] = []
+        for i, lig in enumerate(ligands_in):
+            if not isinstance(lig, dict):
+                continue
+            smiles = str(lig.get("smiles") or "")
+            lid = str(lig.get("id") if lig.get("id") is not None else i)
+            for accession, gene, _pdb_id in panel:
+                rows.append(
+                    _synthesize_secondary_pharma_ligand_ml_row(
+                        smiles=smiles,
+                        ligand_id=lid,
+                        uniprot_id=accession,
+                        gene_name=gene,
+                    )
+                )
+
+        execution["jobOutputs"] = {"ligand_ml_predictions": rows}
+        execution["quotationResult"] = {
+            "anyFailed": False,
+            "failedQuotations": [],
+            "successfulQuotations": [
+                {
+                    "status": "OK",
+                    "itemCode": "DO_SECONDARY_PHARMA",
+                    "orgId": org_key,
+                    "qty": max(len(ligands_in), 1),
+                    "priceEach": 1.0,
+                    "priceTotal": float(max(len(ligands_in), 1)),
+                    "pricingRecordType": "regular",
+                    "pricingRecords": [
+                        {
+                            "itemKey": "DO_SECONDARY_PHARMA",
+                            "itemName": "Secondary Pharmacology ligand-ml scoring",
+                            "priceEach": 1.0,
+                            "totalPrice": float(max(len(ligands_in), 1)),
+                            "qty": max(len(ligands_in), 1),
+                            "tierQtyFrom": 0,
+                            "tierQtyTo": 0,
+                        }
+                    ],
+                }
+            ],
+        }
+        return execution
+
+    def _secondary_pharma_docking_ligands_and_panel(
+        inputs: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], list[tuple[str, str, str]]]:
+        """Resolve ligands (self_test-aware) and the requested panel subset."""
+        if inputs.get("self_test"):
+            ligands_in: list[dict[str, Any]] = [
+                {
+                    "id": None,
+                    "smiles": _MOCK_SECONDARY_PHARMA_SELF_TEST_SMILES,
+                }
+            ]
+        else:
+            ligands_in = [
+                lig for lig in (inputs.get("ligands") or []) if isinstance(lig, dict)
+            ]
+
+        requested_uniprots = inputs.get("uniprots") or None
+        panel = [
+            (accession, gene, pdb_id)
+            for accession, gene, pdb_id in MOCK_SECONDARY_PHARMA_PANEL
+            if requested_uniprots is None or accession in requested_uniprots
+        ]
+        return ligands_in, panel
+
+    def _build_secondary_pharma_docking_execution(
+        *, org_key: str, tool_key: str, tool_version: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build a Running async ``deeporigin.secondary-pharma`` (docking) execution DTO."""
+        now = datetime.now(timezone.utc)
+        ts = now.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        eid = str(uuid.uuid4())
+        approve_amount = body.get("approveAmount", 0) or 0
+        execution: dict[str, Any] = {
+            "executionId": eid,
+            "createdAt": ts,
+            "updatedAt": ts,
+            "resourceId": _generate_resource_id(),
+            "status": "Running",
+            "userInputs": body.get("inputs", {}),
+            "userOutputs": body.get("outputs", {}),
+            "metadata": body.get("metadata", {}),
+            "approveAmount": approve_amount,
+            "jobOutputs": None,
+            "resourcesUsed": None,
+            "resourcesRequested": None,
+            "progressReport": json.dumps({"complete": 0}),
+            "statusReason": None,
+            "name": body.get("name"),
+            "orgKey": org_key,
+            "tool": {"key": tool_key, "version": tool_version},
+            "type": "ToolExecution",
+            "startedAt": ts,
+            "completedAt": None,
+            "quotationResult": {
+                "anyFailed": False,
+                "failedQuotations": [],
+                "successfulQuotations": [],
+            },
+        }
+        if body.get("projectId") is not None:
+            execution["projectId"] = body["projectId"]
+        return execution
+
+    def _inject_secondary_pharma_docking_tool_execution_results(
+        execution: dict[str, Any],
+    ) -> None:
+        """Index synthesized panel_poses rows in result-explorer for a completed async run.
+
+        Matches production async workflow behavior: panel poses are published
+        to the data platform, not echoed in ``jobOutputs`` (mirrors
+        ``_inject_metabolism_tool_execution_results``).
+        """
+        eid = execution.get("executionId")
+        tool = execution.get("tool") or {}
+        tkey = str(tool.get("key") or "deeporigin.secondary-pharma")
+        tool_version = str(tool.get("version") or "0.0.0")
+        if not eid:
+            return
+
+        user_inputs = execution.get("userInputs") or {}
+        if not isinstance(user_inputs, dict):
+            user_inputs = {}
+        ligands_in, panel = _secondary_pharma_docking_ligands_and_panel(user_inputs)
+        effort = int(user_inputs.get("effort") or 1)
+
+        # Real platform behavior (images/secondary-pharma/src/upload_panel_poses.py):
+        # rows with no ligand_id are filtered out before publishing to
+        # result-explorer -- the baked self_test ligand has no id (run.jl),
+        # so a self_test docking run publishes zero panel_poses rows. No
+        # index fallback here (unlike the ligand-ml builder): a fallback
+        # would mask that real, currently-unsupported combination.
+        rows: list[dict[str, Any]] = []
+        for lig in ligands_in:
+            raw_id = lig.get("id")
+            if raw_id is None:
+                continue
+            smiles = str(lig.get("smiles") or "")
+            lid = str(raw_id)
+            for accession, gene, pdb_id in panel:
+                rows.append(
+                    _synthesize_secondary_pharma_panel_pose_row(
+                        ligand_id=lid,
+                        smiles=smiles,
+                        uniprot_id=accession,
+                        gene_name=gene,
+                        pdb_id=pdb_id,
+                        effort=effort,
+                    )
+                )
+
+        execution["jobOutputs"] = {"panel_poses": []}
+        _inject_result_explorer_records_from_outputs(
+            tool_key=tkey,
+            tool_version=tool_version,
+            execution_id=str(eid),
+            job_outputs={"panel_poses": rows},
+        )
 
     def _metabolism_job_outputs_from_inputs(
         inputs: dict[str, Any],
@@ -1753,6 +2032,7 @@ def create_tools_router(
                 "structure_reports",
                 "structurereport",
             ),
+            "deeporigin.secondary-pharma": ("panel_poses", "panelpose"),
         }
 
         entry = output_key_map.get(tool_key)
@@ -2186,6 +2466,29 @@ def create_tools_router(
                             "minItems": 1,
                             "type": "array",
                             "uniqueItems": True,
+                        }
+                    }
+                },
+            }
+        if tool_key == "deeporigin.secondary-pharma":
+            return {
+                "key": tool_key,
+                "name": "deeporigin-secondary-pharma",
+                "version": tool_version,
+                "enabled": enabled,
+                "toolManifestVersion": "5",
+                "description": "Mock secondary-pharma tool definition",
+                "inputs": {
+                    "properties": {
+                        "uniprots": {
+                            "items": {
+                                "enum": [
+                                    accession
+                                    for accession, _, _ in MOCK_SECONDARY_PHARMA_PANEL
+                                ],
+                                "type": "string",
+                            },
+                            "type": "array",
                         }
                     }
                 },
@@ -2742,6 +3045,37 @@ def create_tools_router(
                 execution["completedAt"] = None
                 execution["progressReport"] = None
             executions[execution["executionId"]] = execution
+            return _normalize_execution(execution)
+        if tool_key == "deeporigin.secondary-pharma" and inputs.get("methods") == [
+            "ligand-ml"
+        ]:
+            execution = _build_secondary_pharma_ligand_ml_execution(
+                org_key=org_key,
+                tool_key=tool_key,
+                tool_version=tool_version,
+                body=body,
+            )
+            if quote_only:
+                execution["status"] = "Quoted"
+                execution["jobOutputs"] = None
+                execution["approveAmount"] = 0
+                execution["startedAt"] = None
+                execution["completedAt"] = None
+                execution["progressReport"] = None
+            executions[execution["executionId"]] = execution
+            return _normalize_execution(execution)
+        if tool_key == "deeporigin.secondary-pharma" and inputs.get("methods") == [
+            "docking"
+        ]:
+            execution = _build_secondary_pharma_docking_execution(
+                org_key=org_key,
+                tool_key=tool_key,
+                tool_version=tool_version,
+                body=body,
+            )
+            eid = execution["executionId"]
+            executions[eid] = execution
+            execution_start_times[eid] = datetime.now(timezone.utc)
             return _normalize_execution(execution)
         if tool_key == "deeporigin.metabolism":
             n_ligands = len((body.get("inputs") or {}).get("ligands") or [])

--- a/tests/mock_server/server.py
+++ b/tests/mock_server/server.py
@@ -20,7 +20,6 @@ import uvicorn
 
 from .constants import (
     MOCK_BULK_DOCKING_EXECUTION_ID,
-    MOCK_BULK_DOCKING_POSES_SDF_PATH,
 )
 from .routers import billing, data_platform, entities, files, tools
 from .routers.data_platform import (
@@ -77,6 +76,7 @@ class MockServer:
             "deeporigin.docking": 0.1,  # short poll for local Docking.run (tools API)
             "deeporigin.draco": 3.0,
             "deeporigin.metabolism": 0.1,  # short poll for local Metabolism.start
+            "deeporigin.secondary-pharma": 0.1,  # short poll for local docking start
         }
         self.docking_speed = docking_speed
         self._load_execution_fixtures()

--- a/tests/test_secondary_pharma.py
+++ b/tests/test_secondary_pharma.py
@@ -260,6 +260,24 @@ def test_secondary_pharma_start_validates_effort_before_any_sync(
     assert ligand.id is None, "sync must not have run before the effort check"
 
 
+def test_secondary_pharma_repr_names_correct_entry_point(
+    client: DeepOriginClient,
+) -> None:
+    """``repr()`` points at ``run()`` or ``start()`` matching ``method``.
+
+    Both methods are always present on the instance but only one works;
+    the repr hint is the notebook-facing cue for which one to call.
+    """
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+
+    ml_job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+    assert repr(ml_job).endswith("# call run() to execute synchronously")
+
+    dock_job = SecondaryPharmacology(ligands=[ligand], method="docking", client=client)
+    assert repr(dock_job).endswith("# call start() to execute asynchronously")
+
+
 # --- payload building -----------------------------------------------------------
 
 

--- a/tests/test_secondary_pharma.py
+++ b/tests/test_secondary_pharma.py
@@ -1,0 +1,583 @@
+"""Local mock-server tests for :class:`~deeporigin.drug_discovery.secondary_pharma.SecondaryPharmacology`.
+
+Both execution paths run against the local mock: the ligand-ml path is
+served/sync (mirrors Admet); the docking path is a minimal async completion
+(mirrors Metabolism's async path) that indexes real result-explorer rows via
+``_inject_secondary_pharma_docking_tool_execution_results``, so
+``get_results()``/``get_poses()``'s result-explorer branch gets real coverage
+here, not just the ``jobOutputs``-fallback branch exercised by the hand-built
+DTO tests below. The full Argo submit/poll/complete *timing* is still
+integration-only (dev/staging) -- this mock completes near-instantly, it
+doesn't simulate a real multi-minute workflow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+
+from deeporigin.drug_discovery import BRD_DATA_DIR, Ligand, SecondaryPharmacology
+from deeporigin.drug_discovery.structures.pose import Pose, PoseSet
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.platform.constants import (
+    TERMINAL_STATES,
+    TOOL_KEYS_AND_VERSIONS,
+    is_success_status,
+)
+from tests.conftest import check_tool_exists
+from tests.mock_server.routers.tools import (
+    MOCK_SECONDARY_PHARMA_PANEL,
+    MOCK_SECONDARY_PHARMA_POSE_SDF_PATH,
+    _synthesize_secondary_pharma_ligand_ml_row,
+)
+
+if TYPE_CHECKING:
+    from deeporigin.platform.client import DeepOriginClient
+
+_CFG = TOOL_KEYS_AND_VERSIONS["secondary_pharma"]
+_PANEL_ACCESSIONS = [accession for accession, _, _ in MOCK_SECONDARY_PHARMA_PANEL]
+
+
+def _assert_tool_available(client: DeepOriginClient) -> None:
+    """Require the mock secondary-pharma definition."""
+    assert check_tool_exists(client, _CFG["tool_key"], _CFG["tool_version"])
+
+
+def _definition_enum(client: DeepOriginClient) -> list[str]:
+    """UniProt panel enum from the mock tool definition (independent of the class)."""
+    definition = client.tools.get(
+        tool_key=_CFG["tool_key"],
+        tool_version=_CFG["tool_version"],
+    )
+    return definition["inputs"]["properties"]["uniprots"]["items"]["enum"]
+
+
+# --- construction & validation -----------------------------------------------
+
+
+def test_secondary_pharma_construct_copies_definition_enum(
+    client: DeepOriginClient,
+) -> None:
+    """Construction fetches the live tool definition; ``tool_version`` stays latest."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], client=client)
+
+    assert _definition_enum(client) == _PANEL_ACCESSIONS
+    assert job.tool_version == "latest"
+    assert job.method == "docking"
+    assert job.uniprots is None
+
+
+def test_secondary_pharma_requires_ligands_unless_self_test(
+    client: DeepOriginClient,
+) -> None:
+    """``ligands`` is required unless ``self_test=True``."""
+    _assert_tool_available(client)
+    with pytest.raises(ValueError, match="self_test"):
+        SecondaryPharmacology(client=client)
+
+    job = SecondaryPharmacology(self_test=True, client=client)
+    assert job.ligands == []
+    assert job.self_test is True
+
+
+def test_secondary_pharma_self_test_rejects_ligands(client: DeepOriginClient) -> None:
+    """``self_test=True`` with ``ligands`` given is rejected, not silently ignored.
+
+    The platform tool discards ``ligands`` for a self_test run (baked
+    gefitinib is scored instead) -- passing both would otherwise silently
+    drop the caller's ligands with no signal.
+    """
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    with pytest.raises(ValueError, match="ignored when self_test"):
+        SecondaryPharmacology(ligands=[ligand], self_test=True, client=client)
+
+
+def test_secondary_pharma_uniprots_constructor_rejects_unknown(
+    client: DeepOriginClient,
+) -> None:
+    """An accession outside the live panel enum is rejected at construction."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    with pytest.raises(ValueError, match="Unknown"):
+        SecondaryPharmacology(ligands=[ligand], uniprots=["Q99999"], client=client)
+
+
+def test_secondary_pharma_uniprots_setter_validation(client: DeepOriginClient) -> None:
+    """Draft ``uniprots`` can be replaced, cleared, or rejected."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], client=client)
+
+    job.uniprots = [_PANEL_ACCESSIONS[0]]
+    assert job.uniprots == [_PANEL_ACCESSIONS[0]]
+
+    job.uniprots = None
+    assert job.uniprots is None
+
+    with pytest.raises(ValueError, match="Unknown"):
+        job.uniprots = ["not-an-accession"]
+    with pytest.raises(ValueError, match="non-empty"):
+        job.uniprots = []
+    with pytest.raises(ValueError, match="duplicates"):
+        job.uniprots = [_PANEL_ACCESSIONS[0], _PANEL_ACCESSIONS[0]]
+
+
+def test_secondary_pharma_default_name(client: DeepOriginClient) -> None:
+    """An omitted ``name`` is generated from method/ligands/uniprots/self_test."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+
+    job = SecondaryPharmacology(ligands=[ligand], method="docking", client=client)
+    assert job.name == "SecondaryPharma (docking): 1 ligand vs full panel"
+
+    job2 = SecondaryPharmacology(self_test=True, method="ligand-ml", client=client)
+    assert job2.name == "SecondaryPharma (ligand-ml): self-test vs full panel"
+
+    job3 = SecondaryPharmacology(
+        ligands=[ligand],
+        uniprots=_PANEL_ACCESSIONS[:2],
+        client=client,
+    )
+    assert "2 panel targets" in job3.name
+
+
+# --- method gating -------------------------------------------------------------
+
+
+def test_secondary_pharma_run_rejects_docking_method(client: DeepOriginClient) -> None:
+    """``run()`` is ligand-ml only; docking must use ``start()``."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], method="docking", client=client)
+    with pytest.raises(ValueError, match="start\\("):
+        job.run()
+
+
+def test_secondary_pharma_start_rejects_ligand_ml_method(
+    client: DeepOriginClient,
+) -> None:
+    """``start()`` is docking only; ligand-ml must use ``run()``."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+    with pytest.raises(ValueError, match="run\\("):
+        job.start()
+
+
+def test_secondary_pharma_watch_rejects_ligand_ml_method(
+    client: DeepOriginClient,
+) -> None:
+    """``watch()`` is docking only -- ligand-ml never has an in-flight async job."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+
+    async def _run() -> None:
+        with pytest.raises(ValueError, match="run\\("):
+            await job.watch()
+
+    asyncio.run(_run())
+
+
+def test_secondary_pharma_get_poses_rejects_ligand_ml_method(
+    client: DeepOriginClient,
+) -> None:
+    """``get_poses()`` is docking only."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+    with pytest.raises(ValueError, match="get_results\\("):
+        job.get_poses()
+
+
+def test_secondary_pharma_get_poses_rejects_self_test(client: DeepOriginClient) -> None:
+    """``get_poses()`` refuses a self_test docking run.
+
+    The platform's baked test ligand has no ligand id, so no panel_poses
+    rows are ever published for it -- get_poses() would otherwise either
+    raise an opaque "no results" error or (if jobOutputs happened to carry
+    the rows) fail inside Pose.from_json on the missing ligand_id.
+    """
+    _assert_tool_available(client)
+    job = SecondaryPharmacology(self_test=True, method="docking", client=client)
+    with pytest.raises(ValueError, match="self_test"):
+        job.get_poses()
+
+
+def test_secondary_pharma_run_revalidates_mutated_uniprots(
+    client: DeepOriginClient,
+) -> None:
+    """An in-place ``uniprots`` mutation is caught at ``run()``, not just the setter."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(
+        ligands=[ligand],
+        method="ligand-ml",
+        uniprots=[_PANEL_ACCESSIONS[0]],
+        client=client,
+    )
+    job.uniprots.append("not-an-accession")  # bypasses the setter
+    with pytest.raises(ValueError, match="Unknown"):
+        job.run()
+
+
+def test_secondary_pharma_run_validates_effort_even_on_ligand_ml(
+    client: DeepOriginClient,
+) -> None:
+    """Out-of-range ``effort`` is rejected on ``run()`` too, not just ``start()``.
+
+    The schema has no conditional relaxation of effort's 1-5 bound for the
+    ligand-ml path, so an out-of-range value would otherwise reach the
+    platform and fail there instead of locally.
+    """
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(
+        ligands=[ligand], method="ligand-ml", effort=9, client=client
+    )
+    with pytest.raises(DeepOriginException, match="effort"):
+        job.run()
+
+
+def test_secondary_pharma_start_validates_effort_before_any_sync(
+    client: DeepOriginClient,
+) -> None:
+    """Out-of-range ``effort`` is rejected before ligand sync / submission."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(
+        ligands=[ligand], method="docking", effort=9, client=client
+    )
+    with pytest.raises(DeepOriginException, match="effort"):
+        job.start()
+    assert ligand.id is None, "sync must not have run before the effort check"
+
+
+# --- payload building -----------------------------------------------------------
+
+
+def test_secondary_pharma_make_inputs_omits_ligands_for_self_test(
+    client: DeepOriginClient,
+) -> None:
+    """``self_test=True`` runs have no ligands, so the ``ligands`` key is omitted.
+
+    (The omission itself is just "no ligands to send" -- ``_make_inputs``
+    doesn't special-case ``self_test``; any empty ``self._ligands`` omits
+    the key the same way. The constructor is what ties the two together by
+    requiring ``self_test`` whenever ``ligands`` is empty.)
+    """
+    _assert_tool_available(client)
+    job = SecondaryPharmacology(self_test=True, method="docking", client=client)
+    inputs = job._make_inputs()
+    assert "ligands" not in inputs
+    assert inputs["self_test"] is True
+    assert inputs["methods"] == ["docking"]
+
+
+def test_secondary_pharma_make_inputs_ligand_ml_falls_back_to_index_id(
+    client: DeepOriginClient,
+) -> None:
+    """Ligand-ml rows use the list index as ``id`` when a ligand has none (never synced)."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    assert ligand.id is None
+    job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+    inputs = job._make_inputs()
+    assert inputs["ligands"] == [{"smiles": "CCO", "id": "0"}]
+    assert ligand.id is None, "ligand-ml path must not sync/mutate ligands"
+
+
+def test_secondary_pharma_make_inputs_docking_uses_ligand_id_directly(
+    client: DeepOriginClient,
+) -> None:
+    """Docking rows use ``lig.id``/``lig.smiles`` as-is, assuming a prior sync."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    ligand.id = "manually-set-id"
+    job = SecondaryPharmacology(ligands=[ligand], method="docking", client=client)
+    inputs = job._make_inputs()
+    assert inputs["ligands"] == [{"id": "manually-set-id", "smiles": "CCO"}]
+
+
+def test_secondary_pharma_ensure_platform_inputs_syncs_ligands(
+    client: DeepOriginClient,
+) -> None:
+    """``_ensure_platform_inputs`` (docking-only) syncs ligands to the platform."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    assert ligand.id is None
+    job = SecondaryPharmacology(ligands=[ligand], method="docking", client=client)
+    job._ensure_platform_inputs()
+    assert ligand.id is not None
+
+
+def test_secondary_pharma_make_inputs_includes_uniprots_only_when_set(
+    client: DeepOriginClient,
+) -> None:
+    """``uniprots`` is included when restricted, omitted for the whole panel."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], client=client)
+    assert "uniprots" not in job._make_inputs()
+
+    job.uniprots = [_PANEL_ACCESSIONS[0]]
+    assert job._make_inputs()["uniprots"] == [_PANEL_ACCESSIONS[0]]
+
+
+# --- ligand-ml run() / get_results() -------------------------------------------
+
+
+def test_secondary_pharma_run_ligand_ml_returns_dataframe(
+    client: DeepOriginClient,
+) -> None:
+    """Normal ``run()`` on the ligand-ml path returns one row per ligand x panel member."""
+    _assert_tool_available(client)
+    lig1 = Ligand.from_smiles("CCO")
+    lig2 = Ligand.from_smiles("CCN")
+    job = SecondaryPharmacology(ligands=[lig1, lig2], method="ligand-ml", client=client)
+
+    df = job.run()
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2 * len(_PANEL_ACCESSIONS)
+    assert job.status == "Completed"
+    assert job.id is not None
+    for col in (
+        "ligand_id",
+        "uniprot_id",
+        "gene_name",
+        "ligand_smiles",
+        "p_active",
+        "p_affinity",
+    ):
+        assert col in df.columns
+
+    expected = _synthesize_secondary_pharma_ligand_ml_row(
+        smiles="CCO",
+        ligand_id="0",
+        uniprot_id=_PANEL_ACCESSIONS[0],
+        gene_name=MOCK_SECONDARY_PHARMA_PANEL[0][1],
+    )
+    row = df[
+        (df["ligand_id"] == "0") & (df["uniprot_id"] == _PANEL_ACCESSIONS[0])
+    ].iloc[0]
+    # exactly one of p_active/p_affinity is set per row; the other is None,
+    # which pandas stores as NaN once the column is a float64 dtype.
+    for key in ("p_active", "p_affinity"):
+        if expected[key] is None:
+            assert pd.isna(row[key])
+        else:
+            assert row[key] == expected[key]
+
+
+def test_secondary_pharma_run_ligand_ml_filters_uniprots(
+    client: DeepOriginClient,
+) -> None:
+    """Restricting ``uniprots`` restricts the returned rows to that subset."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(
+        ligands=[ligand],
+        method="ligand-ml",
+        uniprots=[_PANEL_ACCESSIONS[0]],
+        client=client,
+    )
+    df = job.run()
+    assert len(df) == 1
+    assert df.iloc[0]["uniprot_id"] == _PANEL_ACCESSIONS[0]
+
+
+def test_secondary_pharma_run_ligand_ml_self_test_uses_full_panel(
+    client: DeepOriginClient,
+) -> None:
+    """``self_test=True`` scores the baked ligand against the whole panel."""
+    _assert_tool_available(client)
+    job = SecondaryPharmacology(self_test=True, method="ligand-ml", client=client)
+    df = job.run()
+    assert len(df) == len(_PANEL_ACCESSIONS)
+    assert set(df["uniprot_id"]) == set(_PANEL_ACCESSIONS)
+
+
+def test_secondary_pharma_run_quote_true(client: DeepOriginClient) -> None:
+    """``run(quote=True)`` returns the job with an estimate; ligands are unchanged."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    assert ligand.id is None
+    job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+    result = job.run(quote=True)
+
+    assert result is job
+    assert ligand.id is None
+    assert job.estimate is not None
+    assert job.status == "Quoted"
+
+
+def test_secondary_pharma_get_results_ligand_ml_missing_rows_raises(
+    client: DeepOriginClient,
+) -> None:
+    """A DTO with no ``ligand_ml_predictions`` rows raises, not returns empty."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], method="ligand-ml", client=client)
+    empty_dto = {
+        "executionId": "fake-id",
+        "tool": {"key": _CFG["tool_key"], "version": "1"},
+        "jobOutputs": {"ligand_ml_predictions": []},
+    }
+    with pytest.raises(DeepOriginException, match="ligand_ml_predictions"):
+        job.get_results(empty_dto)
+
+
+# --- from_dto / duplicate --------------------------------------------------------
+
+
+def test_secondary_pharma_from_dto_round_trip_ligand_ml(
+    client: DeepOriginClient,
+) -> None:
+    """``from_dto`` restores ligands/method/effort/self_test/uniprots that ran."""
+    _assert_tool_available(client)
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(
+        ligands=[ligand],
+        method="ligand-ml",
+        uniprots=[_PANEL_ACCESSIONS[0]],
+        client=client,
+    )
+    job.run()
+    assert job.dto is not None
+
+    restored = SecondaryPharmacology.from_dto(job.dto, client=client)
+    assert restored.id == job.id
+    assert restored.method == "ligand-ml"
+    assert restored.self_test is False
+    assert restored.ligands[0].smiles == "CCO"
+    assert restored.uniprots == (_PANEL_ACCESSIONS[0],)
+    assert isinstance(restored.uniprots, tuple)
+    with pytest.raises(AttributeError, match="execution id"):
+        restored.uniprots = [_PANEL_ACCESSIONS[1]]
+
+
+def _hand_built_docking_dto(*, self_test: bool = False) -> dict:
+    """A docking-path execution DTO, since local mock never completes one for real."""
+    inputs: dict = {
+        "methods": ["docking"],
+        "effort": 3,
+        "self_test": self_test,
+        "uniprots": list(_PANEL_ACCESSIONS[:2]),
+    }
+    if not self_test:
+        inputs["ligands"] = [{"id": "lig-1", "smiles": "CCO"}]
+    return {
+        "executionId": "docking-hand-built",
+        "status": "Completed",
+        "tool": {"key": _CFG["tool_key"], "version": "2.0.2"},
+        "userInputs": inputs,
+    }
+
+
+def test_secondary_pharma_from_dto_docking(client: DeepOriginClient) -> None:
+    """``from_dto`` on a docking-path DTO restores method/effort/uniprots correctly."""
+    restored = SecondaryPharmacology.from_dto(_hand_built_docking_dto(), client=client)
+    assert restored.method == "docking"
+    assert restored.effort == 3
+    assert restored.self_test is False
+    assert restored.uniprots == tuple(_PANEL_ACCESSIONS[:2])
+    assert restored.ligands[0].smiles == "CCO"
+
+
+def test_secondary_pharma_from_dto_self_test_has_no_ligands(
+    client: DeepOriginClient,
+) -> None:
+    """A self_test DTO (no ``ligands`` in userInputs) rehydrates to an empty list."""
+    restored = SecondaryPharmacology.from_dto(
+        _hand_built_docking_dto(self_test=True), client=client
+    )
+    assert restored.ligands == []
+    assert restored.self_test is True
+
+
+def test_secondary_pharma_duplicate_after_from_dto_makes_uniprots_writable(
+    client: DeepOriginClient,
+) -> None:
+    """``duplicate()`` fetches the definition so a rehydrated draft can set ``uniprots``."""
+    _assert_tool_available(client)
+    restored = SecondaryPharmacology.from_dto(_hand_built_docking_dto(), client=client)
+    # restored already has an execution id, so the id-already-set guard fires
+    # first (same precedence as Admet.properties) -- not the "no definition"
+    # branch, which only matters for an id-less draft.
+    with pytest.raises(AttributeError, match="execution id"):
+        restored.uniprots = [_PANEL_ACCESSIONS[0]]
+
+    copy = restored.duplicate()
+    assert copy.id is None
+    copy.uniprots = [_PANEL_ACCESSIONS[0]]
+    assert copy.uniprots == [_PANEL_ACCESSIONS[0]]
+
+
+# --- docking path: real local mock completion -----------------------------------
+
+
+def test_secondary_pharma_docking_start_sync_get_results_and_poses(
+    client: DeepOriginClient,
+) -> None:
+    """Full docking round trip against the local mock's minimal async completion.
+
+    Exercises ``_load_panel_pose_rows``'s primary (result-explorer) branch for
+    real -- via ``result_type="panelpose"`` -- not just the ``jobOutputs``
+    fallback exercised by the hand-built DTO tests above. The mock completes
+    near-instantly (0.1s); it stands in for "the workflow finished", not for
+    real Argo submit/poll timing, which stays integration-only.
+    """
+    _assert_tool_available(client)
+    client.files.upload(
+        local_path=BRD_DATA_DIR / "brd-2.sdf",
+        remote_path=MOCK_SECONDARY_PHARMA_POSE_SDF_PATH,
+    )
+
+    ligand = Ligand.from_smiles("CCO")
+    job = SecondaryPharmacology(ligands=[ligand], method="docking", client=client)
+    job.start()
+    assert job.id is not None
+    assert ligand.id is not None, "start() syncs the ligand before submitting"
+    synced_ligand_id = ligand.id
+
+    timeout_seconds = 5.0
+    poll_interval = 0.05
+    elapsed = 0.0
+    while elapsed < timeout_seconds:
+        job.sync()
+        if job.status in TERMINAL_STATES:
+            break
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+
+    assert job.status in TERMINAL_STATES
+    assert is_success_status(job.status)
+
+    # Production-like: async DTO has empty jobOutputs; rows live in result-explorer.
+    dto = job.dto or {}
+    assert (dto.get("jobOutputs") or {}).get("panel_poses") == []
+
+    df = job.get_results()
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == len(_PANEL_ACCESSIONS)
+    assert set(df["uniprot_id"]) == set(_PANEL_ACCESSIONS)
+    assert set(df["ligand_id"]) == {synced_ligand_id}
+    for col in ("pose_score", "binding_energy", "file_path", "gene_name", "pdb_id"):
+        assert col in df.columns
+
+    poses = job.get_poses()
+    assert isinstance(poses, PoseSet)
+    assert len(poses) == len(_PANEL_ACCESSIONS)
+    for pose in poses:
+        assert isinstance(pose, Pose)
+        assert pose.ligand_id == synced_ligand_id
+        assert pose.local_path is not None, "get_poses() downloads the SDF"
+        assert pose.smiles is not None

--- a/zensical.toml
+++ b/zensical.toml
@@ -36,6 +36,7 @@ nav = [
       {"SystemPrep" = "dd/tools/systemprep.md"},
       {"Molprops" = "dd/tools/molprops.md"},
       {"Metabolism" = "dd/tools/metabolism.md"},
+      {"Secondary Pharmacology" = "dd/tools/secondary-pharma.md"},
       {"Enumerator" = "dd/tools/enumerator.md"},
       {"Structure Report" = "dd/tools/structure-report.md"},
       {"ABFE" = "dd/tools/abfe.md"},
@@ -76,6 +77,7 @@ nav = [
       {"RBFE" = "dd/ref/rbfe.md"},
       {"Patent" = "dd/ref/patent.md"},
       {"Metabolism" = "dd/ref/metabolism.md"},
+      {"SecondaryPharmacology" = "dd/ref/secondary_pharma.md"},
     ]},
     {"Results" = [
       {"PreparedSystem" = "dd/ref/prepared_system.md"},


### PR DESCRIPTION
## Summary

- Add `SecondaryPharmacology` for `deeporigin.secondary-pharma`: `run()` (served ligand-ml scoring) and `start()` (async docking workflow), gated to their own method since the tool has no `inputs.sync` field to dispatch on
- `get_results()` returns a DataFrame for both paths (`jobOutputs` for ligand-ml, result-explorer for docking, since async completions never populate `jobOutputs`); `get_poses()` (docking-only) builds a downloaded `PoseSet` via `Pose.from_json`
- `self_test` supported on both methods (mutually exclusive with `ligands`); on the docking path neither `get_results()` nor `get_poses()` has anything to return for a self-test run, since the platform publishes no rows for the baked test ligand (no ligand id) — `get_poses()` raises a clear error explaining this
- Mock-server coverage for both paths, docs, and API reference
- Known gaps, not fixed here: the tool-definition enum fetch/validate helpers duplicate `Admet`'s pattern almost verbatim — worth extracting into a shared helper once a third caller needs the same shape; the docking Argo workflow has no ligand batching (`workflow.yaml` is a single task, unlike `deeporigin.docking`'s `batchSize`)

**Jira:** [DDOS-7332](https://deeporigin.atlassian.net/browse/DDOS-7332)

## Test plan

- [x] `uv run pytest tests/test_secondary_pharma.py --env local` (29 passed)
- [x] Live `--env dev` run, both paths: ligand-ml `run()` and full docking `start()` → `wait()` → `get_results()` → `get_poses()` (real Argo workflow, ~110s, 3/3 panel poses downloaded) — confirms the result-explorer read path and `result_type="panelpose"` against the real platform, not just the mock
- [x] Spot-check docs pages for Secondary Pharmacology in the nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DDOS-7332]: https://deeporigin.atlassian.net/browse/DDOS-7332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ