### PR TITLE
fix(platform-sdk): copy tags.py into SDK build staging

### DIFF
--- a/scripts/build_sdk.sh
+++ b/scripts/build_sdk.sh
@@ -21,6 +21,7 @@ cp src/platform/__init__.py platform-sdk/src/platform/
 cp src/platform/client.py platform-sdk/src/platform/
 cp src/platform/files.py platform-sdk/src/platform/
 cp src/platform/entities.py platform-sdk/src/platform/
+cp src/platform/tags.py platform-sdk/src/platform/
 cp src/platform/tools.py platform-sdk/src/platform/
 cp src/platform/results.py platform-sdk/src/platform/
 cp src/__init__.py platform-sdk/src/__init__.py


### PR DESCRIPTION
## Summary

- `scripts/build_sdk.sh` copies an explicit whitelist of files into `platform-sdk/src/`; `tags.py` was never added to it after `entities.py` started depending on it in #582, so every `deeporigin-sdk` release since 5.1.0 ships an `entities.py` that fails to import — silently, since `DeepOriginClient.__init__` swallows the `ImportError` and sets `entities = None`.
- Verified against the published PyPI wheels/sdists for 5.1.0 and 5.1.1: `tags.py` is missing from both, and it's the only broken import in the built package.
- Fix: add `tags.py` to the copy list.

## Test plan

- [x] `bash scripts/build_sdk.sh` then fresh-venv install — `tags.py` present, all submodules import cleanly including `Entities`